### PR TITLE
Apply top_p parameter consistently across all LLM services (closes #10)

### DIFF
--- a/docs/experiments/common_settings.md
+++ b/docs/experiments/common_settings.md
@@ -98,6 +98,7 @@ my_settings = ExperimentSettings(
 - `token_length`: Maximum input context length (in tokens) of the model. **Required** — set it to your model's max input token length. The conversation history is trimmed to fit within this budget.
 - `system_prompt`: A system (development) prompt
 - `temperature`: Temerature of the model (Default: 0.0)
+- `top_p`: Nucleus (top-p) sampling probability, applied consistently across all LLM types (Default: 1.0)
 
 ```python
     models=[
@@ -107,6 +108,7 @@ my_settings = ExperimentSettings(
             token_length=1000000,  # set to your model's max input token length
             system_prompt="You're a helpful assistant",
             temperature=0.0,
+            top_p=1.0,
         )
     ]
 ```

--- a/docs/getting_started/llms.md
+++ b/docs/getting_started/llms.md
@@ -8,7 +8,7 @@ Set `OPENAI_API_KEY` in `.env` file
 OPENAI_API_KEY="[your key]"
 ```
 
-Set your model name in `ExperimentalSettings` in the runner files in `scripts`. You must also set `token_length` (your model's max input token length); the `system_prompt` and `temperature` are optional.
+Set your model name in `ExperimentalSettings` in the runner files in `scripts`. You must also set `token_length` (your model's max input token length); the `system_prompt`, `temperature`, and `top_p` are optional.
 
 ```
 models=[
@@ -18,6 +18,7 @@ models=[
         token_length=1000000,  # set to your model's max input token length
         system_prompt="You're a helpful assistant",
         temperature=0.0,
+        top_p=1.0,
     )
 ```
 
@@ -31,7 +32,7 @@ AZURE_ENDPOINT="[your endpoint]"
 AZURE_API_KEY="[your key]"
 ```
 
-Set your model name in `ExperimentalSettings` in the runner files in `scripts`. You must also set `token_length` (your model's max input token length); the `system_prompt` and `temperature` are optional.
+Set your model name in `ExperimentalSettings` in the runner files in `scripts`. You must also set `token_length` (your model's max input token length); the `system_prompt`, `temperature`, and `top_p` are optional.
 
 ```
 models=[
@@ -41,6 +42,7 @@ models=[
         token_length=1000000,  # set to your model's max input token length
         system_prompt="You're a helpful assistant",
         temperature=0.0,
+        top_p=1.0,
     )
 ```
 
@@ -62,6 +64,7 @@ models=[
         token_length=1048576,  # set to your model's max input token length
         system_prompt="You're a helpful assistant",
         temperature=0.0,
+        top_p=1.0,
     )
 ```
 
@@ -83,6 +86,7 @@ models=[
         token_length=1000000,  # set to your model's max input token length
         system_prompt="You're a helpful assistant",
         temperature=0.0,
+        top_p=1.0,
     )
 ```
 
@@ -100,6 +104,7 @@ models=[
         token_length=128000,  # set to your model's max input token length
         system_prompt="You're a helpful assistant",
         temperature=0.0,
+        top_p=1.0,
     )
 ```
 
@@ -115,6 +120,7 @@ models=[
         token_length=1000000,  # set to your model's max input token length
         system_prompt="You're a helpful assistant",
         temperature=0.0,
+        top_p=1.0,
     ),
     ModelDescription(
         type="gemini",
@@ -122,6 +128,7 @@ models=[
         token_length=1048576,  # set to your model's max input token length
         system_prompt="You're a helpful assistant",
         temperature=0.0,
+        top_p=1.0,
     ),
     ModelDescription(
         type="ollama",
@@ -129,6 +136,7 @@ models=[
         token_length=128000,  # set to your model's max input token length
         system_prompt="You're a helpful assistant",
         temperature=0.0,
+        top_p=1.0,
     )
 ]
 ```

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -21,6 +21,7 @@ The following parameters can be configured via `ExperimentSettings` in the runne
 |Model|All|`token_length`|1000000|Maximum input context length (in tokens) of the model. Required. The conversation history is trimmed to fit within this budget. Set it to your model's max input token length.|
 |Model|All|`system_prompt`|You're a helpful assistant|A system (development) prompt|
 |Model|All|`temperature`|0.0|Temerature of the model (Default: 0.0)|
+|Model|All|`top_p`|1.0|Nucleus (top-p) sampling probability, applied consistently across all LLM types (Default: 1.0)|
 |Tool|All|`name`|opensearch|Name of search tool|
 |Tool|All|`ranking_model`|bm25|Name of ranking model used by the tool|
 |Tool|All|`index_name`|aquaint_bm25|Name of index files used by the tool|

--- a/geniie_lab/services/llm/gemini_llm_service.py
+++ b/geniie_lab/services/llm/gemini_llm_service.py
@@ -36,6 +36,7 @@ class GeminiLLMService:
         model: str,
         token_length: int,
         temperature: float,
+        top_p: float,
         memory: ConversationHistory,
         instruction: InstructionWithGenerate,
         response_model: Type[T]
@@ -62,6 +63,7 @@ class GeminiLLMService:
             config=types.GenerateContentConfig(
                 system_instruction=system_prompt,
                 temperature=temperature,
+                top_p=top_p,
                 response_mime_type="application/json",
                 response_schema=response_model,
             ),
@@ -85,23 +87,23 @@ class GeminiLLMService:
             return token_count
         return count_fn
 
-    def create_query(self, model: str, token_length: int, temperature: float, memory: ConversationHistory, instruction: QueryFormulationInstruction ) -> Tuple[Query, int]:
+    def create_query(self, model: str, token_length: int, temperature: float, top_p: float, memory: ConversationHistory, instruction: QueryFormulationInstruction ) -> Tuple[Query, int]:
 
-        query = self._call_llm_and_parse(model, token_length, temperature, memory, instruction, Query)
+        query = self._call_llm_and_parse(model, token_length, temperature, top_p, memory, instruction, Query)
         return query
 
-    def recreate_query(self, model: str, token_length: int, temperature: float, memory: ConversationHistory, instruction: QueryReFormulationInstruction) -> Tuple[Query, int]:
+    def recreate_query(self, model: str, token_length: int, temperature: float, top_p: float, memory: ConversationHistory, instruction: QueryReFormulationInstruction) -> Tuple[Query, int]:
 
-        query = self._call_llm_and_parse(model, token_length, temperature, memory, instruction, Query)
+        query = self._call_llm_and_parse(model, token_length, temperature, top_p, memory, instruction, Query)
         return query
 
-    def create_clicks(self, model: str, token_length: int, temperature: float, memory: ConversationHistory, instruction: ClickInstruction) -> Tuple[Clicks, int]:
+    def create_clicks(self, model: str, token_length: int, temperature: float, top_p: float, memory: ConversationHistory, instruction: ClickInstruction) -> Tuple[Clicks, int]:
 
-        return self._call_llm_and_parse(model, token_length, temperature, memory, instruction, Clicks)
+        return self._call_llm_and_parse(model, token_length, temperature, top_p, memory, instruction, Clicks)
 
-    def calc_relevance_judgement(self, model: str, token_length: int, temperature: float, memory: ConversationHistory, instruction: RelevanceJudgementInstruction) -> Tuple[RelevanceJudgement, int]:
+    def calc_relevance_judgement(self, model: str, token_length: int, temperature: float, top_p: float, memory: ConversationHistory, instruction: RelevanceJudgementInstruction) -> Tuple[RelevanceJudgement, int]:
 
-        return self._call_llm_and_parse(model, token_length, temperature, memory, instruction, RelevanceJudgement)
+        return self._call_llm_and_parse(model, token_length, temperature, top_p, memory, instruction, RelevanceJudgement)
 
-    def decide_next_action(self, model: str, token_length: int, temperature: float, memory: ConversationHistory, instruction: NextActionInstruction) -> Tuple[NextAction, int]:
-        return self._call_llm_and_parse(model, token_length, temperature, memory, instruction, NextAction)
+    def decide_next_action(self, model: str, token_length: int, temperature: float, top_p: float, memory: ConversationHistory, instruction: NextActionInstruction) -> Tuple[NextAction, int]:
+        return self._call_llm_and_parse(model, token_length, temperature, top_p, memory, instruction, NextAction)

--- a/geniie_lab/services/llm/ollama_llm_service.py
+++ b/geniie_lab/services/llm/ollama_llm_service.py
@@ -37,6 +37,7 @@ class OllamaLLMService:
         model: str,
         token_length: int,
         temperature: float,
+        top_p: float,
         memory: ConversationHistory,
         instruction: InstructionWithGenerate,
         response_model: Type[T]
@@ -52,6 +53,7 @@ class OllamaLLMService:
             messages=messages,
             response_format=response_model,
             temperature=temperature,
+            top_p=top_p,
         )
         parsed_response = completion.choices[0].message.parsed
         if parsed_response is None:
@@ -67,23 +69,23 @@ class OllamaLLMService:
         enc = tiktoken.get_encoding("cl100k_base")
         return lambda text: len(enc.encode(text))
 
-    def create_query(self, model: str, token_length: int, temperature: float, memory: ConversationHistory, instruction: QueryFormulationInstruction) -> Tuple[Query, int]:
+    def create_query(self, model: str, token_length: int, temperature: float, top_p: float, memory: ConversationHistory, instruction: QueryFormulationInstruction) -> Tuple[Query, int]:
 
-        query = self._call_llm_with_pydantic_response(model, token_length, temperature, memory, instruction, Query)
+        query = self._call_llm_with_pydantic_response(model, token_length, temperature, top_p, memory, instruction, Query)
         return query
 
-    def recreate_query(self, model: str, token_length: int, temperature: float, memory: ConversationHistory, instruction: QueryReFormulationInstruction) -> Tuple[Query, int]:
+    def recreate_query(self, model: str, token_length: int, temperature: float, top_p: float, memory: ConversationHistory, instruction: QueryReFormulationInstruction) -> Tuple[Query, int]:
 
-        query = self._call_llm_with_pydantic_response(model, token_length, temperature, memory, instruction, Query)
+        query = self._call_llm_with_pydantic_response(model, token_length, temperature, top_p, memory, instruction, Query)
         return query
 
-    def create_clicks(self, model: str, token_length: int, temperature: float, memory: ConversationHistory, instruction: ClickInstruction) -> Tuple[Clicks, int]:
+    def create_clicks(self, model: str, token_length: int, temperature: float, top_p: float, memory: ConversationHistory, instruction: ClickInstruction) -> Tuple[Clicks, int]:
 
-        return self._call_llm_with_pydantic_response(model, token_length, temperature, memory, instruction, Clicks)
+        return self._call_llm_with_pydantic_response(model, token_length, temperature, top_p, memory, instruction, Clicks)
 
-    def calc_relevance_judgement(self, model: str, token_length: int, temperature: float, memory: ConversationHistory, instruction: RelevanceJudgementInstruction) -> Tuple[RelevanceJudgement, int]:
+    def calc_relevance_judgement(self, model: str, token_length: int, temperature: float, top_p: float, memory: ConversationHistory, instruction: RelevanceJudgementInstruction) -> Tuple[RelevanceJudgement, int]:
 
-        return self._call_llm_with_pydantic_response(model, token_length, temperature, memory, instruction, RelevanceJudgement)
+        return self._call_llm_with_pydantic_response(model, token_length, temperature, top_p, memory, instruction, RelevanceJudgement)
 
-    def decide_next_action(self, model: str, token_length: int, temperature: float, memory: ConversationHistory, instruction: NextActionInstruction) -> Tuple[NextAction, int]:
-        return self._call_llm_with_pydantic_response(model, token_length, temperature, memory, instruction, NextAction)
+    def decide_next_action(self, model: str, token_length: int, temperature: float, top_p: float, memory: ConversationHistory, instruction: NextActionInstruction) -> Tuple[NextAction, int]:
+        return self._call_llm_with_pydantic_response(model, token_length, temperature, top_p, memory, instruction, NextAction)

--- a/scripts/run_agentic_experiment.py
+++ b/scripts/run_agentic_experiment.py
@@ -59,6 +59,7 @@ my_settings = ExperimentSettings(
             token_length=1000000,  # set to your model's max input token length
             system_prompt="You're a helpful assistant",
             temperature=0.0,
+            top_p=1.0,
         ),
         # ModelDescription(
         #     type="azure",
@@ -66,6 +67,7 @@ my_settings = ExperimentSettings(
         #     token_length=1000000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="gemini",
@@ -73,6 +75,7 @@ my_settings = ExperimentSettings(
         #     token_length=1048576,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="ollama",
@@ -80,6 +83,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="ollama",
@@ -87,6 +91,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="openrouter",
@@ -94,6 +99,7 @@ my_settings = ExperimentSettings(
         #     token_length=1000000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="groq",
@@ -101,6 +107,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="vllm",
@@ -108,6 +115,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # )
     ],
     tools=[

--- a/scripts/run_repetition_experiment.py
+++ b/scripts/run_repetition_experiment.py
@@ -59,6 +59,7 @@ my_settings = ExperimentSettings(
             token_length=1000000,  # set to your model's max input token length
             system_prompt="You're a helpful assistant",
             temperature=0.0,
+            top_p=1.0,
         ),
         # ModelDescription(
         #     type="azure",
@@ -66,6 +67,7 @@ my_settings = ExperimentSettings(
         #     token_length=1000000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="gemini",
@@ -73,6 +75,7 @@ my_settings = ExperimentSettings(
         #     token_length=1048576,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="ollama",
@@ -80,6 +83,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="ollama",
@@ -87,6 +91,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="openrouter",
@@ -94,6 +99,7 @@ my_settings = ExperimentSettings(
         #     token_length=1000000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="groq",
@@ -101,6 +107,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="vllm",
@@ -108,6 +115,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # )
     ],
     tools=[

--- a/scripts/run_session_experiment.py
+++ b/scripts/run_session_experiment.py
@@ -59,6 +59,7 @@ my_settings = ExperimentSettings(
             token_length=1000000,  # set to your model's max input token length
             system_prompt="You're a helpful assistant",
             temperature=0.0,
+            top_p=1.0,
         ),
         # ModelDescription(
         #     type="azure",
@@ -66,6 +67,7 @@ my_settings = ExperimentSettings(
         #     token_length=1000000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="gemini",
@@ -73,6 +75,7 @@ my_settings = ExperimentSettings(
         #     token_length=1048576,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="ollama",
@@ -80,6 +83,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="ollama",
@@ -87,6 +91,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="openrouter",
@@ -94,6 +99,7 @@ my_settings = ExperimentSettings(
         #     token_length=1000000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="groq",
@@ -101,6 +107,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # ),
         # ModelDescription(
         #     type="vllm",
@@ -108,6 +115,7 @@ my_settings = ExperimentSettings(
         #     token_length=128000,  # set to your model's max input token length
         #     system_prompt="You're a helpful assistant",
         #     temperature=0.0,
+        #     top_p=1.0,
         # )
     ],
     tools=[

--- a/scripts/run_session_experiment_chiir2026.py
+++ b/scripts/run_session_experiment_chiir2026.py
@@ -49,6 +49,7 @@ my_settings = ExperimentSettings(
             token_length=128000,  # set to your model's max input token length
             system_prompt="You're a helpful assistant",
             temperature=0.0,
+            top_p=1.0,
         )
     ],
     tools=[

--- a/scripts/run_session_experiment_esci.py
+++ b/scripts/run_session_experiment_esci.py
@@ -50,6 +50,7 @@ my_settings = ExperimentSettings(
             token_length=1000000,  # set to your model's max input token length
             system_prompt="You're a helpful assistant",
             temperature=0.0,
+            top_p=1.0,
         ),
     ],
     tools=[


### PR DESCRIPTION
## Summary

Applies `top_p` consistently across all LLM services and their downstream pipelines (issue #10).

`top_p` was already declared on `ModelDescription`, the `LLMServiceProtocol`, and every experiment call site, but the **ollama** and **gemini** services never accepted it — a latent crash for those two providers, since the experiments pass `model.top_p` positionally.

## Changes

- **ollama** ([ollama_llm_service.py](geniie_lab/services/llm/ollama_llm_service.py)): thread `top_p` through the helper and all 5 public methods; pass `top_p` to `chat.completions.parse()` (a documented OpenAI-compat field).
- **gemini** ([gemini_llm_service.py](geniie_lab/services/llm/gemini_llm_service.py)): thread `top_p` through `_call_llm_and_parse` and all 5 public methods; pass `top_p` into `GenerateContentConfig`.
- `top_p` stays `Optional[float] = 1.0` (mirrors `temperature`; 1.0 is a safe universal passthrough), so existing scripts keep working.
- **scripts**: surface `top_p=1.0` alongside `temperature=0.0` in every `ModelDescription` (active and commented) across all runners.
- **docs**: document `top_p` in `parameters.md`, `common_settings.md`, and `llms.md`.

## Verification

- All 7 services now uniformly thread `top_p` (matching the protocol and call sites); touched Python compiles cleanly.
- Confirmed against official docs that both providers support the parameter on the endpoints used: Ollama lists `top_p` as a supported `/v1/chat/completions` field, and Gemini documents `top_p` on `GenerateContentConfig`.
- Recommended before merge: one real run against a live **ollama** and **gemini** model, since this is the first time those two providers actually send `top_p` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)