### PR TITLE
Use encode_query for DPR search (closes #20)

### DIFF
--- a/geniie_lab/services/opensearch/opensearch_client_dpr.py
+++ b/geniie_lab/services/opensearch/opensearch_client_dpr.py
@@ -108,7 +108,7 @@ class OpenSearchClientDPR:
         start: int = 0,
         size: int = 10
     ) -> Serp:
-        query_vector = self.model.encode(query).tolist()
+        query_vector = self.model.encode_query(query).tolist()
         search_body = {
             "from": start,
             "size": size,


### PR DESCRIPTION
## Summary
Completes issue #20 by migrating the **DPR** search client to the prompt-aware sentence-transformers API.

`OpenSearchClientDPR.search_index_with_snippets` encoded the user query with the plain, non-prompt-aware `self.model.encode(query)`. This switches it to `self.model.encode_query(query)`, applying the correct query-side prompt for asymmetric retrieval models.

This mirrors the earlier SPLADE migration (commit b0a20c5), which already adopted `SparseEncoder.encode_query()` for the same search-method context. With this change both dense (DPR) and sparse (SPLADE) clients consistently use the prompt-aware `encode_query`/`encode_document` API family.

## Change
```diff
- query_vector = self.model.encode(query).tolist()
+ query_vector = self.model.encode_query(query).tolist()
```

`encode_query()` returns the same numpy array type as `encode()`, so `.tolist()` is unaffected.

## Testing
- Parse/syntax check passes; confirmed sentence-transformers 5.1.0 exposes `encode_query()` on `SentenceTransformer`.
- The live retrieval path (requires a running OpenSearch instance + `msmarco-distilbert-base-tas-b` download) was not exercised in this environment. Low risk — a drop-in method swap matching the accepted SPLADE precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)