### PR TITLE
Phase 0a: behavior fixes (B1-B7)

### DIFF
--- a/geniie_lab/dataclasses/serp.py
+++ b/geniie_lab/dataclasses/serp.py
@@ -1,5 +1,5 @@
 # Standard library
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
 # Third-party libraries
@@ -12,6 +12,10 @@ class SearchResultItem(DataClassJsonMixin):
     docid: str
     title: str
     snippet: str
+    # Retrieval score from the search engine, used for evaluation only.
+    # repr=False keeps it out of the SERP rendered into LLM instructions:
+    # the simulated searcher must not see engine scores.
+    score: float = field(default=0.0, repr=False)
 
 @dataclass_json
 @dataclass

--- a/geniie_lab/experiments/agentic_experiment.py
+++ b/geniie_lab/experiments/agentic_experiment.py
@@ -96,7 +96,9 @@ class RankingStage:
 
         run = Run()
         for result in state.serp.results:
-            run.add(state.topic.id, result.docid, result.ranking)
+            # ir_measures ranks by descending score (TREC run convention), so
+            # pass the engine's retrieval score, not the 1-based SERP ranking.
+            run.add(state.topic.id, result.docid, result.score)
         results = MeasureService().calc(settings.task.measurement, qrels, run)
 
         output = RankingExperimentOutput(

--- a/geniie_lab/experiments/agentic_experiment.py
+++ b/geniie_lab/experiments/agentic_experiment.py
@@ -387,56 +387,60 @@ class ExperimentRunner:
                 opensearch_client = self.opensearch_client_factory.create_opensearch_client(settings=self.settings, tool=tool)
 
                 for topic in self.topics:
-                    llm_service = self.llm_factory.create_llm_service(model.type)
-                    print(f"\n{'--'*10} Topic: {topic.id} ({topic.title}) {'--'*10}", file=sys.stderr)
+                    self._run_topic(topic, model, tool, opensearch_client)
 
-                    memory = ConversationHistory(system_role=model.system_role, system_prompt=model.system_prompt)
-                    state = ExperimentState(topic=topic, memory=memory)
+    def _run_topic(self, topic, model, tool, opensearch_client):
+        """Run the action loop for one topic. Returning ends this topic only."""
+        llm_service = self.llm_factory.create_llm_service(model.type)
+        print(f"\n{'--'*10} Topic: {topic.id} ({topic.title}) {'--'*10}", file=sys.stderr)
 
-                    state.next_action = NextAction(action=Action.SUBMIT_NEW_QUERY, reason="initial bootstrap")
+        memory = ConversationHistory(system_role=model.system_role, system_prompt=model.system_prompt)
+        state = ExperimentState(topic=topic, memory=memory)
 
-                    while state.action_num < self.settings.max_actions:
-                        stage_names = []
+        state.next_action = NextAction(action=Action.SUBMIT_NEW_QUERY, reason="initial bootstrap")
 
-                        if state.next_action and state.next_action.action != Action.END_TASK:
-                            action_enum = getattr(state.next_action, "action", None)
-                            stage_names = self.action_stage_map.get(action_enum, [])
+        while state.action_num < self.settings.max_actions:
+            stage_names = []
 
-                        for stage_name in stage_names:
-                            if stage_name not in self.stage_runners:
-                                print(f"[ERROR] Unknown stage: {stage_name}", file=sys.stderr)
-                                sys.exit(1)
+            if state.next_action and state.next_action.action != Action.END_TASK:
+                action_enum = getattr(state.next_action, "action", None)
+                stage_names = self.action_stage_map.get(action_enum, [])
 
-                            if stage_name == "ranking" and action_enum == Action.GO_NEXT_RESULT_PAGE:
-                                state.query.start += 10
+            for stage_name in stage_names:
+                if stage_name not in self.stage_runners:
+                    print(f"[ERROR] Unknown stage: {stage_name}", file=sys.stderr)
+                    sys.exit(1)
 
-                            stage_runner = self.stage_runners[stage_name]
-                            state = stage_runner.run(self.settings, state, llm_service, model, tool, opensearch_client, stage_name)
-                            
-                            if state.error:
-                                print(f"[WARNING] in stage '{stage_name}': {state.error}. Stopping pipeline for this topic.", file=sys.stderr)
-                                
-                                if self.settings.full_log:
-                                    print(f"\n{'--'*10} Full Log {'--'*10}", file=sys.stderr)
-                                    all_messages = state.memory.get_all_messages()
-                                    pprint.pprint(all_messages, stream=sys.stderr)
+                if stage_name == "ranking" and action_enum == Action.GO_NEXT_RESULT_PAGE:
+                    state.query.start += 10
 
-                                state.error = None
-                                return
-                            
-                            if stage_name == "next_action" and state.next_action.action == Action.END_TASK:
-                                print(f"\n{'='*20} Agent decided to end the task. {'='*20}", file=sys.stderr)
+                stage_runner = self.stage_runners[stage_name]
+                state = stage_runner.run(self.settings, state, llm_service, model, tool, opensearch_client, stage_name)
 
-                                if self.settings.full_log:
-                                    print(f"\n{'--'*10} Full Log {'--'*10}", file=sys.stderr)
-                                    all_messages = state.memory.get_all_messages()
-                                    pprint.pprint(all_messages, stream=sys.stderr)
-                                
-                                return
-
-                            state.action_num += 1
+                if state.error:
+                    print(f"[WARNING] in stage '{stage_name}': {state.error}. Stopping pipeline for this topic.", file=sys.stderr)
 
                     if self.settings.full_log:
                         print(f"\n{'--'*10} Full Log {'--'*10}", file=sys.stderr)
                         all_messages = state.memory.get_all_messages()
                         pprint.pprint(all_messages, stream=sys.stderr)
+
+                    state.error = None
+                    return
+
+                if stage_name == "next_action" and state.next_action.action == Action.END_TASK:
+                    print(f"\n{'='*20} Agent decided to end the task. {'='*20}", file=sys.stderr)
+
+                    if self.settings.full_log:
+                        print(f"\n{'--'*10} Full Log {'--'*10}", file=sys.stderr)
+                        all_messages = state.memory.get_all_messages()
+                        pprint.pprint(all_messages, stream=sys.stderr)
+
+                    return
+
+                state.action_num += 1
+
+        if self.settings.full_log:
+            print(f"\n{'--'*10} Full Log {'--'*10}", file=sys.stderr)
+            all_messages = state.memory.get_all_messages()
+            pprint.pprint(all_messages, stream=sys.stderr)

--- a/geniie_lab/experiments/agentic_experiment.py
+++ b/geniie_lab/experiments/agentic_experiment.py
@@ -109,7 +109,7 @@ class RankingStage:
             dataset=settings.topicset.name,
             topic_id=state.topic.id,
             doc_ids=state.docids,
-            start = settings.task.start_offset,
+            start=start_offset,  # the offset actually used for this search
             size=settings.task.serp_size,
             performance=results
         )
@@ -412,7 +412,7 @@ class ExperimentRunner:
                     sys.exit(1)
 
                 if stage_name == "ranking" and action_enum == Action.GO_NEXT_RESULT_PAGE:
-                    state.query.start += 10
+                    state.query.start += self.settings.task.serp_size
 
                 stage_runner = self.stage_runners[stage_name]
                 state = stage_runner.run(self.settings, state, llm_service, model, tool, opensearch_client, stage_name)

--- a/geniie_lab/experiments/repetition_experiment.py
+++ b/geniie_lab/experiments/repetition_experiment.py
@@ -107,7 +107,7 @@ class RankingStage:
             dataset=settings.topicset.name,
             topic_id=state.topic.id,
             doc_ids=state.docids,
-            start=settings.task.start_offset,
+            start=start_offset,  # the offset actually used for this search
             size=settings.task.serp_size,
             performance=results,
             repetition=repetition

--- a/geniie_lab/experiments/repetition_experiment.py
+++ b/geniie_lab/experiments/repetition_experiment.py
@@ -94,7 +94,9 @@ class RankingStage:
 
         run = Run()
         for result in state.serp.results:
-            run.add(state.topic.id, result.docid, result.ranking)
+            # ir_measures ranks by descending score (TREC run convention), so
+            # pass the engine's retrieval score, not the 1-based SERP ranking.
+            run.add(state.topic.id, result.docid, result.score)
         results = MeasureService().calc(settings.task.measurement, qrels, run)
 
         output = RankingExperimentOutput(

--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -94,7 +94,9 @@ class RankingStage:
 
         run = Run()
         for result in state.serp.results:
-            run.add(state.topic.id, result.docid, result.ranking)
+            # ir_measures ranks by descending score (TREC run convention), so
+            # pass the engine's retrieval score, not the 1-based SERP ranking.
+            run.add(state.topic.id, result.docid, result.score)
         results = MeasureService().calc(settings.task.measurement, qrels, run)
 
         output = RankingExperimentOutput(

--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -355,6 +355,7 @@ class ExperimentRunner:
                         if state.error:
                             print(f"[WARNING] in stage '{stage_name}': {state.error}. Stopping pipeline for this topic.", file=sys.stderr)
                             state.error = None
+                            break
                     
                     if self.settings.full_log:
                         print(f"\n{'--'*10} Full Log {'--'*10}", file=sys.stderr)

--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -107,7 +107,7 @@ class RankingStage:
             dataset=settings.topicset.name,
             topic_id=state.topic.id,
             doc_ids=state.docids,
-            start = settings.task.start_offset,
+            start=start_offset,  # the offset actually used for this search
             size=settings.task.serp_size,
             performance=results
         )

--- a/geniie_lab/services/llm/azure_llm_service.py
+++ b/geniie_lab/services/llm/azure_llm_service.py
@@ -5,7 +5,6 @@ from typing import Callable, Protocol, Tuple, Type, TypeVar
 # Third-party libraries
 from dotenv import load_dotenv
 from openai import AzureOpenAI
-from openai.types.chat import ChatCompletionUserMessageParam
 from pydantic import BaseModel
 import tiktoken
 
@@ -48,10 +47,9 @@ class AzureOpenAILLMService:
     ) -> Tuple[T, int]:
 
         memory.add_user_message(instruction.generate())
-        messages_dicts: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
-        messages: list[ChatCompletionUserMessageParam] = [
-            ChatCompletionUserMessageParam(role="user", content=msg["content"]) for msg in messages_dicts
-        ]
+        # Pass roles through unchanged: the system prompt and previous assistant
+        # turns must not be re-sent as user messages.
+        messages: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
         completion = self.client.beta.chat.completions.parse(
             model=model,
             messages=messages,

--- a/geniie_lab/services/llm/groq_llm_service.py
+++ b/geniie_lab/services/llm/groq_llm_service.py
@@ -5,7 +5,6 @@ from typing import Callable, Protocol, Tuple, Type, TypeVar
 # Third-party libraries
 from dotenv import load_dotenv
 from openai import OpenAI
-from openai.types.chat import ChatCompletionUserMessageParam
 from pydantic import BaseModel
 import tiktoken
 
@@ -47,10 +46,9 @@ class GroqLLMService:
     ) -> Tuple[T, int]:
 
         memory.add_user_message(instruction.generate())
-        messages_dicts: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
-        messages: list[ChatCompletionUserMessageParam] = [
-            ChatCompletionUserMessageParam(role="user", content=msg["content"]) for msg in messages_dicts
-        ]
+        # Pass roles through unchanged: the system prompt and previous assistant
+        # turns must not be re-sent as user messages.
+        messages: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
         completion = self.client.beta.chat.completions.parse(
             model=model,
             messages=messages,

--- a/geniie_lab/services/llm/ollama_llm_service.py
+++ b/geniie_lab/services/llm/ollama_llm_service.py
@@ -4,7 +4,6 @@ from typing import Callable, Protocol, Tuple, Type, TypeVar
 # Third-party libraries
 from dotenv import load_dotenv
 from openai import OpenAI
-from openai.types.chat import ChatCompletionUserMessageParam
 from pydantic import BaseModel
 import tiktoken
 
@@ -44,10 +43,9 @@ class OllamaLLMService:
     ) -> Tuple[T, int]:
 
         memory.add_user_message(instruction.generate())
-        messages_dicts: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
-        messages: list[ChatCompletionUserMessageParam] = [
-            ChatCompletionUserMessageParam(role="user", content=msg["content"]) for msg in messages_dicts
-        ]
+        # Pass roles through unchanged: the system prompt and previous assistant
+        # turns must not be re-sent as user messages.
+        messages: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
         completion = self.client.beta.chat.completions.parse(
             model=model,
             messages=messages,

--- a/geniie_lab/services/llm/openai_llm_service.py
+++ b/geniie_lab/services/llm/openai_llm_service.py
@@ -4,7 +4,6 @@ from typing import Callable, Protocol, Tuple, Type, TypeVar
 # Third-party libraries
 from dotenv import load_dotenv
 from openai import OpenAI
-from openai.types.chat import ChatCompletionUserMessageParam
 from pydantic import BaseModel
 import tiktoken
 
@@ -42,10 +41,9 @@ class OpenAILLMService:
     ) -> Tuple[T, int]:
 
         memory.add_user_message(instruction.generate())
-        messages_dicts: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
-        messages: list[ChatCompletionUserMessageParam] = [
-            ChatCompletionUserMessageParam(role="user", content=msg["content"]) for msg in messages_dicts
-        ]
+        # Pass roles through unchanged: the system prompt and previous assistant
+        # turns must not be re-sent as user messages.
+        messages: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
         completion = self.client.beta.chat.completions.parse(
             model=model,
             messages=messages,

--- a/geniie_lab/services/llm/openrouter_llm_service.py
+++ b/geniie_lab/services/llm/openrouter_llm_service.py
@@ -5,7 +5,6 @@ from typing import Callable, Protocol, Tuple, Type, TypeVar
 # Third-party libraries
 from dotenv import load_dotenv
 from openai import OpenAI
-from openai.types.chat import ChatCompletionUserMessageParam
 from pydantic import BaseModel
 import tiktoken
 
@@ -47,10 +46,9 @@ class OpenRouterLLMService:
     ) -> Tuple[T, int]:
 
         memory.add_user_message(instruction.generate())
-        messages_dicts: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
-        messages: list[ChatCompletionUserMessageParam] = [
-            ChatCompletionUserMessageParam(role="user", content=msg["content"]) for msg in messages_dicts
-        ]
+        # Pass roles through unchanged: the system prompt and previous assistant
+        # turns must not be re-sent as user messages.
+        messages: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
         completion = self.client.beta.chat.completions.parse(
             model=model,
             messages=messages,

--- a/geniie_lab/services/llm/vllm_llm_service.py
+++ b/geniie_lab/services/llm/vllm_llm_service.py
@@ -4,7 +4,6 @@ from typing import Callable, Protocol, Tuple, Type, TypeVar
 # Third-party libraries
 from dotenv import load_dotenv
 from openai import OpenAI
-from openai.types.chat import ChatCompletionUserMessageParam
 from pydantic import BaseModel
 import tiktoken
 
@@ -44,10 +43,9 @@ class VllmLLMService:
     ) -> Tuple[T, int]:
 
         memory.add_user_message(instruction.generate())
-        messages_dicts: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
-        messages: list[ChatCompletionUserMessageParam] = [
-            ChatCompletionUserMessageParam(role="user", content=msg["content"]) for msg in messages_dicts
-        ]
+        # Pass roles through unchanged: the system prompt and previous assistant
+        # turns must not be re-sent as user messages.
+        messages: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
         completion = self.client.beta.chat.completions.parse(
             model=model,
             messages=messages,

--- a/geniie_lab/services/opensearch/opensearch_client_bm25.py
+++ b/geniie_lab/services/opensearch/opensearch_client_bm25.py
@@ -79,6 +79,7 @@ class OpenSearchClientBM25:
                 ranking=start + idx,
                 docid=src.get("docid"),
                 title=self.clean_text(src.get("title", "No Title")),
-                snippet=snippet_text
+                snippet=snippet_text,
+                score=hit.get("_score") or 0.0
             ))
         return Serp(hits=total_hits, results=items)

--- a/geniie_lab/services/opensearch/opensearch_client_bm25.py
+++ b/geniie_lab/services/opensearch/opensearch_client_bm25.py
@@ -46,10 +46,12 @@ class OpenSearchClientBM25:
         try:
             self.docstore = self.dataset.docs_store()
             doc = self.docstore.get(docid)
-            text = getattr(doc, 'text', None) or getattr(doc, 'body', None) or '' 
+            text = getattr(doc, 'text', None) or getattr(doc, 'body', None) or ''
+            title = getattr(doc, 'title', None)
             return FullText(
                 docid = docid,
-                text = self.clean_text(text)
+                text = self.clean_text(text),
+                title = self.clean_text(title) if title else None
             )
         except Exception as e:
             return Error(error_text=str(e))

--- a/geniie_lab/services/opensearch/opensearch_client_dpr.py
+++ b/geniie_lab/services/opensearch/opensearch_client_dpr.py
@@ -54,10 +54,12 @@ class OpenSearchClientDPR:
         try:
             self.docstore = self.dataset.docs_store()
             doc = self.docstore.get(docid)
-            text = getattr(doc, 'text', None) or getattr(doc, 'body', None) or '' 
+            text = getattr(doc, 'text', None) or getattr(doc, 'body', None) or ''
+            title = getattr(doc, 'title', None)
             return FullText(
                 docid = docid,
-                text = self.clean_text(text)
+                text = self.clean_text(text),
+                title = self.clean_text(title) if title else None
             )
         except Exception as e:
             return Error(error_text=str(e))

--- a/geniie_lab/services/opensearch/opensearch_client_dpr.py
+++ b/geniie_lab/services/opensearch/opensearch_client_dpr.py
@@ -146,7 +146,8 @@ class OpenSearchClientDPR:
                 ranking=start + idx,
                 docid=src.get("docid"),
                 title=self.clean_text(src.get("title", "No Title")),
-                snippet=snippet_text
+                snippet=snippet_text,
+                score=hit.get("_score") or 0.0
             ))
 
         return Serp(hits=total_hits, results=items)

--- a/geniie_lab/services/opensearch/opensearch_client_splade.py
+++ b/geniie_lab/services/opensearch/opensearch_client_splade.py
@@ -54,10 +54,12 @@ class OpenSearchClientSplade:
         try:
             self.docstore = self.dataset.docs_store()
             doc = self.docstore.get(docid)
-            text = getattr(doc, 'text', None) or getattr(doc, 'body', None) or '' 
+            text = getattr(doc, 'text', None) or getattr(doc, 'body', None) or ''
+            title = getattr(doc, 'title', None)
             return FullText(
                 docid = docid,
-                text = self.clean_text(text)
+                text = self.clean_text(text),
+                title = self.clean_text(title) if title else None
             )
         except Exception as e:
             return Error(error_text=str(e))

--- a/geniie_lab/services/opensearch/opensearch_client_splade.py
+++ b/geniie_lab/services/opensearch/opensearch_client_splade.py
@@ -103,6 +103,7 @@ class OpenSearchClientSplade:
                 ranking=start + idx,
                 docid=src.get("docid"),
                 title=self.clean_text(src.get("title", "No Title")),
-                snippet=snippet_text
+                snippet=snippet_text,
+                score=hit.get("_score") or 0.0
             ))
         return Serp(hits=total_hits, results=items)


### PR DESCRIPTION
First phase of the refactoring plan: seven correctness fixes, one commit each, before any structural work. Each commit's diff shows exactly which behavior changed and nothing else.

## Fixes

| Commit | Fix |
|---|---|
| B1 | **Evaluation scores were inverted**: RankingStage fed the 1-based SERP ranking to ir_measures as the document *score*; ir_measures ranks by descending score, so every SERP was evaluated in reverse order. Now captures the engine's real `_score` in `SearchResultItem` (`repr=False`, so scores are not disclosed to the LLM in prompts) and passes that to ir_measures. |
| B2 | Session runner printed "Stopping pipeline for this topic" on stage error but had no `break` — remaining stages ran against inconsistent state. |
| B3 | Agentic runner's `return` on END_TASK/error ended the *whole experiment*, silently skipping all remaining topics/tools/models. Per-topic loop extracted to `_run_topic()`. |
| B4 | All six OpenAI-compatible services re-sent the system prompt and assistant history as `role="user"` messages (Gemini preserved roles). Roles now pass through unchanged. |
| B5 | `RankingExperimentOutput.start` logged the configured `task.start_offset` instead of the offset actually used for the search. |
| B6 | GO_NEXT_RESULT_PAGE paged by a hardcoded `10` instead of `serp_size`. |
| B7 | `FullText.title` was never populated — judged documents were presented to the model as `**Document**: None`. |

## ⚠️ Impact on results

**B1 and B4 change reported numbers.** Verified for B1 with a toy example through `MeasureService`: a relevant document at rank 1 of a 3-doc SERP scored nDCG@10=0.5 / MRR@10=0.33 before the fix, 1.0/1.0 after. Re-run baselines before comparing against pre-fix results. The pre-fix state is tagged `refactor-baseline`.

Note: with real scores, ir_measures breaks score *ties* by doc-id, so tied documents may be evaluated in a slightly different order than displayed.

## Verification

- `python -m compileall geniie_lab` clean; all touched modules import.
- B1 exercised end-to-end through `MeasureService` (toy qrels/run) and prompt-disclosure checked (`score` absent from generated ClickInstruction).
- Phase 0b (next PR) adds the test suite asserting these fixed behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)