### PR TITLE
Phase 0b: test suite asserting fixed behavior

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+
+import ir_datasets
+import ir_measures
+import pytest
+
+from geniie_lab.dataclasses.description import (
+    CorpusDescription,
+    ModelDescription,
+    TaskDescription,
+    ToolDescription,
+    TopicDescription,
+)
+from geniie_lab.dataclasses.setting import ExperimentSettings
+from geniie_lab.dataclasses.topic import FullTopic
+from geniie_lab.services.llm.llm_service_factory import LLMServiceFactory
+from geniie_lab.services.opensearch.opensearch_client_factory import OpenSearchClientFactory
+
+from tests.fakes import FakeLLMService, FakeOpenSearchClient, default_dataset
+
+
+@pytest.fixture
+def fake_llm():
+    return FakeLLMService()
+
+
+@pytest.fixture
+def fake_search():
+    return FakeOpenSearchClient()
+
+
+@pytest.fixture
+def fake_dataset():
+    return default_dataset()
+
+
+@pytest.fixture
+def patched_services(monkeypatch, fake_llm, fake_search, fake_dataset):
+    """Route the runners' three external seams to fakes: ir_datasets and the
+    two service factories. No network, no OpenSearch, no LLM API."""
+    monkeypatch.setattr(ir_datasets, "load", lambda name: fake_dataset)
+    monkeypatch.setattr(
+        LLMServiceFactory, "create_llm_service",
+        lambda self, genai_type: fake_llm,
+    )
+    monkeypatch.setattr(
+        OpenSearchClientFactory, "create_opensearch_client",
+        lambda self, settings, tool: fake_search,
+    )
+    return SimpleNamespace(llm=fake_llm, search=fake_search, dataset=fake_dataset)
+
+
+def make_settings(name="test_experiment", plan=None, loop_num_per_topic=1,
+                  max_actions=None) -> ExperimentSettings:
+    return ExperimentSettings(
+        name=name,
+        task=TaskDescription(
+            name="High-Recall Retrieval",
+            description="Find as many relevant documents as possible.",
+            measurement=[ir_measures.nDCG@10, ir_measures.MRR@10],
+            start_offset=0,
+            serp_size=10,
+        ),
+        topicset=TopicDescription(
+            name="fake/dataset",
+            type="ir_datasets",
+            topic_class=FullTopic,
+        ),
+        corpus=CorpusDescription(
+            name="Fake Corpus",
+            description="A fake corpus for testing.",
+            index_name="fake_bm25",
+        ),
+        models=[
+            ModelDescription(type="fake", name="fake-model", token_length=100000),
+        ],
+        tools=[
+            ToolDescription(
+                name="opensearch",
+                ranking_model="bm25",
+                index_name="fake_bm25",
+                description="A fake search tool.",
+            ),
+        ],
+        plan=plan,
+        loop_num_per_topic=loop_num_per_topic,
+        max_actions=max_actions,
+    )

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,133 @@
+# Test doubles for the geniie-lab service protocols.
+#
+# FakeLLMService mimics the real services' observable contract: it appends the
+# generated instruction as a user message and its response as an assistant
+# message to the ConversationHistory, and returns (response, total_token).
+import json
+from collections import namedtuple
+from typing import List
+
+from geniie_lab.dataclasses.serp import FullText, SearchResultItem, Serp
+from geniie_lab.response import (
+    Action,
+    Clicks,
+    NextAction,
+    Query,
+    Relevance,
+    RelevanceJudgement,
+)
+
+FAKE_TOTAL_TOKEN = 42
+
+FakeQuery = namedtuple("FakeQuery", ["query_id", "title", "description", "narrative"])
+FakeQrel = namedtuple("FakeQrel", ["query_id", "doc_id", "relevance"])
+
+
+class FakeDataset:
+    """Stands in for an ir_datasets dataset (queries_iter / qrels_iter)."""
+
+    def __init__(self, queries: List[FakeQuery], qrels: List[FakeQrel]):
+        self._queries = queries
+        self._qrels = qrels
+
+    def queries_iter(self):
+        return iter(self._queries)
+
+    def qrels_iter(self):
+        return iter(self._qrels)
+
+
+def default_dataset() -> FakeDataset:
+    return FakeDataset(
+        queries=[
+            FakeQuery("t1", "topic one", "description one", "narrative one"),
+            FakeQuery("t2", "topic two", "description two", "narrative two"),
+        ],
+        # Only d1 is relevant, and only for t1. The fake SERP always returns
+        # d1 at rank 1 with the highest score, so t1 must score RR@10 = 1.0.
+        qrels=[FakeQrel("t1", "d1", 1)],
+    )
+
+
+class FakeLLMService:
+    """Implements LLMServiceProtocol with canned responses.
+
+    `calls` records (method_name, history_len_before_call) so tests can assert
+    memory-cloning semantics. `next_actions` is a FIFO of Action values for
+    decide_next_action; when exhausted it returns END_TASK.
+    """
+
+    def __init__(self, next_actions: List[Action] | None = None):
+        self.calls: list[tuple[str, int]] = []
+        self.next_actions: list[Action] = list(next_actions or [])
+
+    def _respond(self, method, memory, instruction, response):
+        self.calls.append((method, len(memory._history)))
+        memory.add_user_message(instruction.generate())
+        memory.add_assistant_response(response.model_dump_json())
+        return response, FAKE_TOTAL_TOKEN
+
+    def create_query(self, model, token_length, temperature, top_p, memory, instruction):
+        return self._respond(
+            "create_query", memory, instruction,
+            Query(query="first query", start=0, size=10, reason="initial query"),
+        )
+
+    def recreate_query(self, model, token_length, temperature, top_p, memory, instruction):
+        return self._respond(
+            "recreate_query", memory, instruction,
+            Query(query="reformulated query", start=0, size=10, reason="try again"),
+        )
+
+    def create_clicks(self, model, token_length, temperature, top_p, memory, instruction):
+        return self._respond(
+            "create_clicks", memory, instruction,
+            Clicks(ranking_list=[1], reason="top result looks relevant"),
+        )
+
+    def calc_relevance_judgement(self, model, token_length, temperature, top_p, memory, instruction):
+        return self._respond(
+            "calc_relevance_judgement", memory, instruction,
+            RelevanceJudgement(label=Relevance.RELEVANT, reason="on topic"),
+        )
+
+    def decide_next_action(self, model, token_length, temperature, top_p, memory, instruction):
+        action = self.next_actions.pop(0) if self.next_actions else Action.END_TASK
+        return self._respond(
+            "decide_next_action", memory, instruction,
+            NextAction(action=action, reason="fake decision"),
+        )
+
+    def get_tokenizer(self, model_name):
+        return lambda text: len(text)
+
+
+class FakeOpenSearchClient:
+    """Implements OpenSearchClientProtocol with a fixed two-document SERP.
+
+    d1 always ranks first with the highest score. `searches` records
+    (query, start, size) so tests can assert pagination behavior.
+    """
+
+    def __init__(self):
+        self.searches: list[tuple[str, int, int]] = []
+
+    def clean_text(self, text: str) -> str:
+        return text
+
+    def search_index_with_snippets(self, query: str, start: int = 0, size: int = 10) -> Serp:
+        self.searches.append((query, start, size))
+        return Serp(hits=2, results=[
+            SearchResultItem(ranking=start + 1, docid="d1", title="Doc One",
+                             snippet="about topic one", score=2.0),
+            SearchResultItem(ranking=start + 2, docid="d2", title="Doc Two",
+                             snippet="about something else", score=1.0),
+        ])
+
+    def fetch_fulltext(self, docid: str) -> FullText:
+        return FullText(docid=docid, text=f"Full text of {docid}.", title=f"Title of {docid}")
+
+
+def parse_jsonl(text: str) -> list[dict]:
+    """Parse the experiment's stdout data channel into a list of records."""
+    return [json.loads(line) for line in text.strip().splitlines() if line.strip()]

--- a/tests/test_agentic_experiment.py
+++ b/tests/test_agentic_experiment.py
@@ -1,0 +1,57 @@
+from geniie_lab.experiments.agentic_experiment import ExperimentRunner
+from geniie_lab.response import Action
+
+from tests.conftest import make_settings
+from tests.fakes import parse_jsonl
+
+# The bootstrap action is SUBMIT_NEW_QUERY, which maps to this stage cycle.
+CYCLE = ["query", "ranking", "click", "rel_judge", "next_action"]
+
+
+def test_end_task_ends_topic_not_experiment(patched_services, capsys):
+    # B3: the fake decides END_TASK on the first decision of every topic;
+    # topic t2 must still run after t1 ends its task.
+    settings = make_settings(name="test_agentic", max_actions=10)
+    ExperimentRunner(settings=settings).run()
+    records = parse_jsonl(capsys.readouterr().out)
+
+    t1 = [r["stage"] for r in records if r["topic_id"] == "t1"]
+    t2 = [r["stage"] for r in records if r["topic_id"] == "t2"]
+    assert t1 == CYCLE
+    assert t2 == CYCLE  # pre-B3, t2 was silently skipped
+
+    end = next(r for r in records if r["stage"] == "next_action")
+    assert end["action"] == "END_TASK"
+
+
+def test_go_next_result_page_paginates_by_serp_size(patched_services, capsys):
+    # B5+B6: GO_NEXT_RESULT_PAGE advances the search offset by serp_size and
+    # the ranking record logs the offset actually used.
+    patched_services.llm.next_actions = [Action.GO_NEXT_RESULT_PAGE, Action.END_TASK]
+    settings = make_settings(max_actions=20)
+    ExperimentRunner(settings=settings).run()
+    records = parse_jsonl(capsys.readouterr().out)
+
+    t1_searches = patched_services.search.searches[:2]
+    assert t1_searches == [("first query", 0, 10), ("first query", 10, 10)]
+
+    t1_ranking_starts = [r["start"] for r in records
+                         if r["topic_id"] == "t1" and r["stage"] == "ranking"]
+    assert t1_ranking_starts == [0, 10]
+
+    # GO_NEXT_RESULT_PAGE skips the query stage: ranking, click, relevance, decide.
+    t1 = [r["stage"] for r in records if r["topic_id"] == "t1"]
+    assert t1 == CYCLE + ["ranking", "click", "rel_judge", "next_action"]
+
+
+def test_max_actions_terminates_the_loop(patched_services, capsys):
+    # The fake keeps requesting new queries; the action budget must stop it.
+    patched_services.llm.next_actions = [Action.SUBMIT_NEW_QUERY] * 50
+    settings = make_settings(max_actions=7)
+    ExperimentRunner(settings=settings).run()
+    records = parse_jsonl(capsys.readouterr().out)
+
+    # action_num is checked at the start of each cycle (1 and 6 pass, 11 does
+    # not), so exactly two full cycles run per topic.
+    t1 = [r["stage"] for r in records if r["topic_id"] == "t1"]
+    assert t1 == CYCLE * 2

--- a/tests/test_repetition_experiment.py
+++ b/tests/test_repetition_experiment.py
@@ -1,0 +1,46 @@
+from geniie_lab.experiments.repetition_experiment import ExperimentRunner
+
+from tests.conftest import make_settings
+from tests.fakes import parse_jsonl
+
+
+def test_last_stage_repeats_with_repetition_numbers(patched_services, capsys):
+    settings = make_settings(name="test_repetition", plan=["query"], loop_num_per_topic=3)
+    ExperimentRunner(settings=settings).run()
+    records = parse_jsonl(capsys.readouterr().out)
+
+    # plan[:-1] is empty; the single "query" stage repeats 3x per topic.
+    assert [r["stage"] for r in records] == ["query"] * 6
+    assert [r["repetition"] for r in records] == [1, 2, 3, 1, 2, 3]
+    assert [r["topic_id"] for r in records] == ["t1"] * 3 + ["t2"] * 3
+
+
+def test_each_repetition_starts_from_cloned_base_memory(patched_services, capsys):
+    # Every repeated create_query call must see the same (empty) base history:
+    # the runner clones base memory before each repetition instead of letting
+    # repetitions contaminate one another.
+    settings = make_settings(plan=["query"], loop_num_per_topic=3)
+    ExperimentRunner(settings=settings).run()
+    capsys.readouterr()
+
+    assert [call for call in patched_services.llm.calls] == [("create_query", 0)] * 6
+
+
+def test_prefix_stages_run_once_and_are_shared_by_repetitions(patched_services, capsys):
+    # plan = query, ranking, click: the prefix (query, ranking) runs once per
+    # topic; only "click" repeats. Each click call must start from the same
+    # base history (the 2 messages added by the query stage).
+    settings = make_settings(plan=["query", "ranking", "click"], loop_num_per_topic=2)
+    ExperimentRunner(settings=settings).run()
+    records = parse_jsonl(capsys.readouterr().out)
+
+    per_topic_stages = ["query", "ranking", "click", "click"]
+    assert [r["stage"] for r in records] == per_topic_stages * 2
+
+    clicks = [r for r in records if r["stage"] == "click"]
+    assert [r["repetition"] for r in clicks] == [1, 2, 1, 2]
+
+    click_calls = [c for c in patched_services.llm.calls if c[0] == "create_clicks"]
+    # 2 topics x 2 repetitions, each starting from the cloned base history of
+    # exactly 2 messages (user instruction + assistant response of the query stage).
+    assert click_calls == [("create_clicks", 2)] * 4

--- a/tests/test_session_experiment.py
+++ b/tests/test_session_experiment.py
@@ -1,0 +1,72 @@
+import math
+
+from geniie_lab.experiments.session_experiment import ExperimentRunner
+
+from tests.conftest import make_settings
+from tests.fakes import FAKE_TOTAL_TOKEN, parse_jsonl
+
+
+def test_full_plan_emits_expected_record_sequence(patched_services, capsys):
+    settings = make_settings(
+        name="test_session",
+        plan=["query", "ranking", "click", "relevance", "reformulate"],
+    )
+    ExperimentRunner(settings=settings).run()
+    records = parse_jsonl(capsys.readouterr().out)
+
+    # 2 topics x 5 stages, in plan order.
+    expected_stages = ["query", "ranking", "click", "rel_judge", "reformulation"]
+    assert [r["stage"] for r in records] == expected_stages * 2
+    assert [r["topic_id"] for r in records] == ["t1"] * 5 + ["t2"] * 5
+
+    query_rec = records[0]
+    assert query_rec["query"] == "first query"
+    assert query_rec["session_name"] == "test_session"
+    assert query_rec["model"] == "fake-model"
+    assert query_rec["dataset"] == "fake/dataset"
+    assert query_rec["total_token"] == FAKE_TOTAL_TOKEN
+
+    reform_rec = records[4]
+    assert reform_rec["query"] == "reformulated query"
+
+
+def test_ranking_evaluates_serp_in_display_order(patched_services, capsys):
+    # B1: the relevant doc d1 is at rank 1 (highest retrieval score), so the
+    # metrics must reflect a top-ranked hit -- not the reversed SERP.
+    settings = make_settings(plan=["query", "ranking"])
+    ExperimentRunner(settings=settings).run()
+    records = parse_jsonl(capsys.readouterr().out)
+
+    rank_t1 = next(r for r in records if r["stage"] == "ranking" and r["topic_id"] == "t1")
+    assert rank_t1["doc_ids"] == ["d1", "d2"]
+    assert rank_t1["performance"]["nDCG@10"] == 1.0
+    assert rank_t1["performance"]["RR@10"] == 1.0
+
+    # t2 has no qrels at all: ir_measures aggregates to NaN, which is emitted
+    # verbatim into the JSONL (a bare NaN token -- tolerated by Python's json
+    # module but invalid strict JSON; recorded here as current behavior).
+    rank_t2 = next(r for r in records if r["stage"] == "ranking" and r["topic_id"] == "t2")
+    assert math.isnan(rank_t2["performance"]["RR@10"])
+
+
+def test_relevance_stage_reports_qrel_label(patched_services, capsys):
+    settings = make_settings(plan=["query", "ranking", "click", "relevance"])
+    ExperimentRunner(settings=settings).run()
+    records = parse_jsonl(capsys.readouterr().out)
+
+    rel_t1 = next(r for r in records if r["stage"] == "rel_judge" and r["topic_id"] == "t1")
+    assert rel_t1["docid"] == "d1"
+    assert rel_t1["qrel_label"] == 1
+    rel_t2 = next(r for r in records if r["stage"] == "rel_judge" and r["topic_id"] == "t2")
+    assert rel_t2["qrel_label"] == 0
+
+
+def test_stage_error_stops_plan_for_topic(patched_services, capsys):
+    # B2: "click" errors without a SERP; the remaining stages of the plan must
+    # not run for that topic.
+    settings = make_settings(plan=["click", "query"])
+    ExperimentRunner(settings=settings).run()
+    records = parse_jsonl(capsys.readouterr().out)
+
+    assert records == []  # click errored; query never ran for either topic
+    assert patched_services.llm.calls == []

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,112 @@
+import math
+
+import ir_measures
+import pytest
+
+from geniie_lab.dataclasses.description import (
+    CorpusDescription,
+    TaskDescription,
+    ToolDescription,
+)
+from geniie_lab.dataclasses.instruction import (
+    ClickInstruction,
+    QueryFormulationInstruction,
+    RelevanceJudgementInstruction,
+)
+from geniie_lab.dataclasses.serp import FullText, SearchResultItem, Serp
+from geniie_lab.dataclasses.topic import FullTopic
+from geniie_lab.memory import ConversationHistory
+from geniie_lab.services.measure_service import MeasureService, Qrels, Run
+
+
+# --- ConversationHistory -----------------------------------------------------
+
+def test_memory_defaults_to_system_role():
+    memory = ConversationHistory(system_role=None, system_prompt="be helpful")
+    assert memory.get_all_messages() == [{"role": "system", "content": "be helpful"}]
+
+
+def test_memory_prunes_oldest_messages_first():
+    memory = ConversationHistory(system_role=None, system_prompt="sys")
+    for i in range(5):
+        memory.add_user_message(f"msg-{i}")
+
+    # One token per message: budget of 3 keeps the system prompt plus the two
+    # most recent messages, in chronological order.
+    messages = memory.get_messages(tokenizer=lambda text: 1, max_tokens=3)
+    assert [m["content"] for m in messages] == ["sys", "msg-3", "msg-4"]
+
+
+def test_memory_clone_is_independent():
+    memory = ConversationHistory(system_role=None, system_prompt="sys")
+    memory.add_user_message("original")
+    clone = memory.clone()
+    clone.add_user_message("only in clone")
+
+    assert len(memory.get_all_messages()) == 2
+    assert len(clone.get_all_messages()) == 3
+
+
+# --- MeasureService -----------------------------------------------------------
+
+def test_measures_match_hand_computed_values():
+    # d1 is relevant but scored below d2, so it lands at rank 2:
+    # RR = 1/2, nDCG@10 = (1/log2(3)) / (1/log2(2)) = 0.6309...
+    qrels = Qrels()
+    qrels.add("t1", "d1", 1)
+    run = Run()
+    run.add("t1", "d1", 1.0)
+    run.add("t1", "d2", 2.0)
+
+    results = MeasureService().calc([ir_measures.nDCG@10, ir_measures.MRR@10], qrels, run)
+    assert results["RR@10"] == pytest.approx(0.5)
+    assert results["nDCG@10"] == pytest.approx(1 / math.log2(3))
+
+
+# --- Instruction prompts --------------------------------------------------------
+
+def _serp() -> Serp:
+    return Serp(hits=2, results=[
+        SearchResultItem(ranking=1, docid="d1", title="Doc One",
+                         snippet="first snippet", score=12.5),
+        SearchResultItem(ranking=2, docid="d2", title="Doc Two",
+                         snippet="second snippet", score=3.25),
+    ])
+
+
+def test_query_formulation_prompt_contains_all_sections():
+    prompt = QueryFormulationInstruction(
+        instruction="Formulate a query.",
+        task=TaskDescription(name="T", description="the task", measurement=[]),
+        corpus=CorpusDescription(name="C", description="the corpus", index_name="idx"),
+        tool=ToolDescription(name="opensearch", ranking_model="bm25",
+                             index_name="idx", description="the tool"),
+        topic=FullTopic(id="t1", title="the title", description="the description",
+                        narrative="the narrative"),
+    ).generate()
+
+    for fragment in ["Formulate a query.", "the task", "the corpus", "the tool",
+                     "the title", "the description", "the narrative"]:
+        assert fragment in prompt
+
+
+def test_click_prompt_shows_serp_but_not_retrieval_scores():
+    # B1's disclosure guard: the simulated searcher sees titles and snippets,
+    # never the engine's scores.
+    prompt = ClickInstruction(instruction="Pick documents.", serp=_serp()).generate()
+
+    assert "Doc One" in prompt and "first snippet" in prompt
+    assert "score" not in prompt
+    assert "12.5" not in prompt and "3.25" not in prompt
+
+
+def test_relevance_prompt_contains_document_title_and_text():
+    # B7: fetch_fulltext populates the title, and the prompt renders it.
+    prompt = RelevanceJudgementInstruction(
+        instruction="Judge relevance.",
+        fulltext=FullText(docid="d1", text="the full text", title="the doc title"),
+    ).generate()
+
+    assert "the doc title" in prompt
+    assert "the full text" in prompt
+    assert "None" not in prompt


### PR DESCRIPTION
Second phase of the refactoring plan: a test suite (17 tests, all offline, ~30ms) asserting the behavior fixed in #31. Stacked on `refactor/phase-0a-behavior-fixes`; will retarget to `dev` when #31 merges.

## Structure

- `tests/fakes.py` — `FakeLLMService` (mimics the real services' memory contract, records call history for memory-cloning assertions) and `FakeOpenSearchClient` (fixed 2-doc SERP, records searches for pagination assertions), plus a fake ir_datasets dataset.
- `tests/conftest.py` — routes the runners' three external seams (`ir_datasets.load` + both service factories) to the fakes; `make_settings()` builder.
- `test_session_experiment.py` — full-plan JSONL record sequence, SERP evaluated in display order (B1), qrel labels, error stops the plan (B2).
- `test_repetition_experiment.py` — repetition numbering, prefix-runs-once, and the memory-cloning contract (every repetition starts from the same cloned base history).
- `test_agentic_experiment.py` — action→stage mapping, END_TASK ends the topic not the experiment (B3), pagination by serp_size with actual offset logged (B5+B6), max_actions termination.
- `test_units.py` — ConversationHistory pruning/cloning, MeasureService vs hand-computed nDCG/RR, prompt content: SERP rendered **without** retrieval scores (B1 disclosure guard), document title rendered in relevance prompts (B7).

## Observation recorded, not fixed

A topic with no qrels yields `NaN` from ir_measures, emitted verbatim into the JSONL — a bare `NaN` token is invalid strict JSON (Python's parser tolerates it; `jq`/JS would not). Asserted as current behavior in `test_session_experiment.py`; candidate for a later fix.

`pytest` is currently installed ad hoc in the venv; it gets declared as a dev dependency in Phase 6 (pyproject.toml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)