### PR TITLE
Work around Groq comma-dropping in Clicks.ranking_list

### DIFF
--- a/geniie_lab/response.py
+++ b/geniie_lab/response.py
@@ -53,7 +53,13 @@ class Clicks(BaseModel):
         title="ranking_list",
         description=(
             "The ranking number of the documents in the result to examine the full text. "
-        )
+        ),
+        # gpt-oss-120b on Groq drops commas between bare integers in
+        # constrained decoding ([2, 9] is emitted as [29]). Declaring string
+        # items in the JSON schema forces quoted, comma-separated elements;
+        # pydantic then coerces each "2" back to int, so ranking_list stays
+        # List[int] for all downstream code.
+        json_schema_extra=lambda schema: schema.update({"items": {"type": "string"}}),
     )
     reason: str = Field(
         ...,


### PR DESCRIPTION
## Summary

Fixes #35 — Groq's constrained decoding for `openai/gpt-oss-120b` emits integer arrays without separators (`[2, 9]` arrives as `[29]`), so any multi-document click produces an invalid rank that aborts the relevance stage.

One-field change to `Clicks.ranking_list` in `geniie_lab/response.py`: keep the Python type `List[int]`, but use `json_schema_extra` to advertise `"items": {"type": "string"}` in the JSON schema sent to the provider. The quotes force Groq's grammar to keep elements separated; pydantic coerces `"2"` → `2` on validation, so `ranking_list` reaches all downstream code as genuine ints — no other changes needed.

## Verification

- **Without fix (Groq):** 6/6 harness runs + 3/3 minimal-repro trials returned concatenated ranks (`[12345678910]`, `[1235910]`, `[29]`, `[256]`); every full-session attempt aborted at the relevance stage.
- **With fix (Groq):** minimal repro 3/3 correct (`[1, 2, ..., 10]`); full 4-stage session ran with a 10-doc click parsed correctly and 5 relevance judgments completed (run then hit free-tier TPM limits — unrelated).
- **Provider-agnostic:** local vLLM serving the same model works identically before and after (it never had the bug; quoted numbers coerce the same way).
- Prompt-level fixes were tested and do not work (the defect is in the decoding grammar, not model understanding), so the schema override is the minimal effective change.

The workaround can be dropped if Groq fixes their integer-array grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)