### PR TITLE
Constrain Clicks.ranking_list items to numeric strings

### DIFF
--- a/geniie_lab/response.py
+++ b/geniie_lab/response.py
@@ -52,14 +52,22 @@ class Clicks(BaseModel):
         ...,
         title="ranking_list",
         description=(
-            "The ranking number of the documents in the result to examine the full text. "
+            "The ranking numbers of the documents in the result to examine the full text. "
+            'Each element is one ranking number as a numeric string, e.g. ["2", "5", "7"]. '
+            "Use ranking numbers, not document IDs."
         ),
-        # gpt-oss-120b on Groq drops commas between bare integers in
-        # constrained decoding ([2, 9] is emitted as [29]). Declaring string
-        # items in the JSON schema forces quoted, comma-separated elements;
-        # pydantic then coerces each "2" back to int, so ranking_list stays
-        # List[int] for all downstream code.
-        json_schema_extra=lambda schema: schema.update({"items": {"type": "string"}}),
+        # Prevention layer, from strongest to weakest:
+        #  - "type": "string"  — Groq's constrained decoder drops commas between
+        #    bare integers ([2, 9] arrives as [29]); quoted items force separators.
+        #  - "pattern": "^[0-9]{1,3}$" — grammar-enforcing providers can then ONLY
+        #    emit digit strings, making document IDs ("LA043090-0036") impossible.
+        #  - the description's example and "not document IDs" steer providers that
+        #    enforce schemas loosely (local vLLM).
+        # pydantic coerces each "2" back to int, so ranking_list stays List[int]
+        # for all downstream code.
+        json_schema_extra=lambda schema: schema.update(
+            {"items": {"type": "string", "pattern": "^[0-9]{1,3}$"}}
+        ),
     )
     reason: str = Field(
         ...,


### PR DESCRIPTION
## Summary

Follow-up to #36 (issue #35). The string-items schema fixed Groq's comma-dropping, but introduced a regression on providers that enforce JSON schemas loosely: with items typed as unconstrained strings, gpt-oss-120b on local vLLM interpreted `ranking_list` as wanting **document IDs** and returned `['LA043090-0036', 'FBIS4-67701', ...]`, which fails pydantic's int coercion and crashes the click stage.

This PR adds two layers on top of the string-items workaround:

- `"pattern": "^[0-9]{1,3}$"` on the items — grammar-enforcing providers can then only emit rank numbers, making document IDs impossible to generate.
- An explicit format example in the field description (`["2", "5", "7"]`, "Use ranking numbers, not document IDs") — steers providers that treat the schema as advisory.

`ranking_list` remains `List[int]` in Python; nothing downstream changes.

## Verification

- Standalone repro: 3/3 correct on **Groq** and 3/3 on **local vLLM** (same model, temperature 0).
- Full two-iteration sessions (`query→ranking→click→relevance→reformulate→ranking→click→relevance`) via vLLM on two topics: Robust 2004 topic 303 (multi-doc clicks `[3, 5, 7, 8]`, `[1, 3]`) and topic 309 (single-doc clicks `[1]`, `[8]`) — all 8 stages completed, no validation errors.
- Without this patch, the same two-iteration runs crashed at the first click stage with `int_parsing` errors on both attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)