### PR TITLE
Update splade/dpr search for the chunked nested index schema

### DIFF
--- a/geniie_lab/services/opensearch/opensearch_client_dpr.py
+++ b/geniie_lab/services/opensearch/opensearch_client_dpr.py
@@ -66,16 +66,16 @@ class OpenSearchClientDPR:
 
     def generate_snippet(
         self,
-        passage_chunks: List[dict],
+        passage_chunks: List[str],
         query: str,
         max_segments: int = 1,
         max_segment_length: int = 150
     ) -> str:
         """
-        Generate a snippet composed of the top N segments (passage chunks)
-        that match the query terms, based on lexical overlap.
+        Generate a snippet composed of the top N passages that match the
+        query terms, based on lexical overlap.
 
-        :param passage_chunks: List of passage chunk dicts.
+        :param passage_chunks: List of passage texts (the text_chunks field).
         :param query: User query string.
         :param max_segments: Number of segments to return.
         :param max_segment_length: Max characters per segment.
@@ -86,21 +86,16 @@ class OpenSearchClientDPR:
 
         query_terms = set(re.findall(r'\w+', query.lower()))
 
-        # Score chunks by number of query term overlaps
-        def score_chunk(chunk):
-            text = chunk.get("text", "")
+        # Score passages by number of query term overlaps
+        def score_chunk(text: str) -> int:
             words = re.findall(r'\w+', text.lower())
             return sum(1 for w in words if w in query_terms)
 
-        # Sort chunks by overlap score (descending)
+        # Sort passages by overlap score (descending)
         ranked_chunks = sorted(passage_chunks, key=score_chunk, reverse=True)
 
         # Take top N and clean/truncate
-        selected = []
-        for chunk in ranked_chunks[:max_segments]:
-            raw = chunk.get("text", "")
-            clean = self.clean_text(raw)[:max_segment_length]
-            selected.append(clean)
+        selected = [self.clean_text(raw)[:max_segment_length] for raw in ranked_chunks[:max_segments]]
 
         return " ... ".join(selected) if selected else "No snippet available"
 
@@ -114,13 +109,18 @@ class OpenSearchClientDPR:
         search_body = {
             "from": start,
             "size": size,
+            # Documents are chunked at indexing time; per-passage dense
+            # vectors live in the nested text_chunks_embedding field and the
+            # passage texts in the parallel top-level text_chunks array. The
+            # query is encoded client-side (participants' OpenSearch users
+            # have no ML-plugin permissions), so a raw vector is sent.
             "query": {
                 "nested": {
-                    "path": "passage_chunk",
-                    "score_mode": "max",
+                    "path": "text_chunks_embedding",
+                    "score_mode": "max",  # best-matching passage sets the doc score
                     "query": {
                         "knn": {
-                            "passage_chunk.embedding": {
+                            "text_chunks_embedding.knn": {
                                 "vector": query_vector,
                                 "k": size
                             }
@@ -129,8 +129,7 @@ class OpenSearchClientDPR:
                 }
             },
             "_source": {
-                "includes": ["docid", "title", "passage_chunk"],
-                "excludes": ["passage_chunk.embedding"]
+                "includes": ["docid", "title", "text_chunks"]
             }
         }
         response = self.client.search(index=self.index_name, body=search_body)
@@ -140,7 +139,7 @@ class OpenSearchClientDPR:
         items: List[SearchResultItem] = []
         for idx, hit in enumerate(response.get("hits", {}).get("hits", []), start=1):
             src = hit.get("_source", {})
-            passage_chunks = src.get("passage_chunk", [])
+            passage_chunks = src.get("text_chunks", [])
 
             snippet_text = self.generate_snippet(passage_chunks, query=query)
 

--- a/geniie_lab/services/opensearch/opensearch_client_splade.py
+++ b/geniie_lab/services/opensearch/opensearch_client_splade.py
@@ -75,19 +75,35 @@ class OpenSearchClientSplade:
         search_body = {
             "from": start,
             "size": size,
+            # Documents are chunked at indexing time; per-passage sparse
+            # vectors live in the nested text_chunks_embedding field. The
+            # query is encoded client-side (participants' OpenSearch users
+            # have no ML-plugin permissions), so raw query_tokens are sent.
             "query": {
-                "neural_sparse": {
-                    "sparse_embedding": {
-                        "query_tokens": dict(query_embedding[0])
+                "nested": {
+                    "path": "text_chunks_embedding",
+                    "score_mode": "max",  # best-matching passage sets the doc score
+                    "query": {
+                        "neural_sparse": {
+                            "text_chunks_embedding.sparse_encoding": {
+                                "query_tokens": dict(query_embedding[0])
+                            }
+                        }
                     }
                 }
+            },
+            "_source": {
+                "excludes": ["text_chunks_embedding"]
             },
             "highlight": {
                 "fields": {
                     "text": {
                         "type": "plain",
                         "fragment_size": 150,
-                        "number_of_fragments": 1
+                        "number_of_fragments": 1,
+                        # The nested neural query carries no lexical terms for
+                        # the highlighter; highlight against the raw query text.
+                        "highlight_query": {"match": {"text": query}}
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Fixes #41 — the splade and dpr OpenSearch clients queried pre-chunking schemas; against the current geniie-backend `dev` indexes (nested `text_chunks_embedding` with per-passage `sparse_encoding` rank_features / `knn` vectors) splade failed on every search with `[neural_sparse] query only works on [rank_features] fields`.

Both clients now use the reference search shape from `geniie-backend/retrieval/opensearch_{splade,dpr}_search.ipynb` — `nested` query on `path: text_chunks_embedding` with `score_mode: max` — with one deliberate difference: query encoding stays **client-side** via `encode_model` (raw `query_tokens` / vector) instead of the notebooks' server-side `query_text` + `model_id`, since participants' OpenSearch users have no ML-plugin permissions.

- **splade** — nested `neural_sparse` on `text_chunks_embedding.sparse_encoding`; embeddings excluded from `_source`; the plain highlighter gets a lexical `highlight_query` (the neural query carries no terms to highlight)
- **dpr** — nested `knn` on `text_chunks_embedding.knn`; snippet generation reworked for the top-level `text_chunks` passage strings

## Verification

- splade: 1-topic smoke sessions (query→ranking→click→relevance) against `trec_robust_2004_splade` on both fold1 and fold2 — real ranked results (recall 0.123 / 0.009 on topics 302/301), full pipeline clean; previously failed at the first ranking call. Full 50-topic baseline runs are in progress on this code.
- dpr: updated to the same reference shape; not runtime-tested (no NTCIR-19 dpr requirement; needs the dense encode model). Flagging for a smoke test before any dpr-dependent use.
- Note: the query encoder loads on GPU when available; on a GPU busy with vLLM it OOMs — run with `CUDA_VISIBLE_DEVICES=""` to force CPU encoding (fast for query-length inputs). Possibly worth a docs note or a device parameter later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)