### PR TITLE
Continue the session when the LLM clicks no documents

### DIFF
--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -158,8 +158,14 @@ class RelevanceJudgementStage:
         self.config = config
 
     def run(self, settings: ExperimentSettings, state: ExperimentState, llm_service: LLMServiceProtocol, model: ModelDescription, tool: ToolDescription, opensearch_client: OpenSearchClientProtocol) -> ExperimentState:
-        if not state.clicks or not state.serp or not state.clicks.ranking_list:
-            state.error = "Clicks/SERP not found or no documents clicked, cannot run RelevanceJudgementStage."
+        if not state.clicks or not state.serp:
+            state.error = "Clicks/SERP not found, cannot run RelevanceJudgementStage."
+            return state
+        if not state.clicks.ranking_list:
+            # An empty click list is a legitimate agent decision, not an
+            # error: skip the judgements and let the session continue with
+            # the rest of the plan (e.g. reformulate in the next iteration).
+            print("\n--- Skipping: Relevance Judgement Stage (no documents clicked) ---", file=sys.stderr)
             return state
 
         dataset = ir_datasets.load(settings.topicset.name)


### PR DESCRIPTION
## Summary

Fixes #43 — in session experiments, an empty click list (an explicitly allowed response: "Return an empty list if none of the results appears relevant") set `state.error`, and the runner then dropped the topic's remaining iterations. In the 5-iteration baseline runs this cut 3–7 topics short per configuration.

The guard in `RelevanceJudgementStage` is split: missing `clicks`/`serp` state remains an error; an empty `ranking_list` skips the judgement stage with a `--- Skipping ... ---` log note and lets the plan continue. Expected behaviour restored: no click → no judgements → reformulate (if iterations remain).

`repetition_experiment.py` is intentionally unchanged — there is nothing after the repeated stage to continue to, so stopping on nothing-to-judge remains appropriate there.

## Verification

- Unit: empty `ranking_list` → no error, stage skipped; `clicks=None` → error preserved.
- E2E (2-iteration session on Robust 2004 fold2 topic 680, Bedrock): with a click instruction forcing empty lists, the log shows click `[]` → `Skipping: Relevance Judgement Stage` → Query Re-formulation → ranking → click, for both iterations, no warnings.
- Regression: the same topic with default instructions runs all 8 stages normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)