### PR TITLE
Raise OpenSearch client timeouts and retry on timeout

### DIFF
--- a/geniie_lab/services/opensearch/opensearch_client_bm25.py
+++ b/geniie_lab/services/opensearch/opensearch_client_bm25.py
@@ -33,6 +33,11 @@ class OpenSearchClientBM25:
             verify_certs=False,
             ssl_assert_hostname=False,
             ssl_show_warn=False,
+            # Nested neural queries on chunked indexes can exceed the 10s
+            # default read timeout under load.
+            timeout=60,
+            retry_on_timeout=True,
+            max_retries=2,
         )
         self.index_name = index_name
         self.dataset = ir_datasets.load(dataset_name)

--- a/geniie_lab/services/opensearch/opensearch_client_dpr.py
+++ b/geniie_lab/services/opensearch/opensearch_client_dpr.py
@@ -36,6 +36,11 @@ class OpenSearchClientDPR:
             verify_certs=False,
             ssl_assert_hostname=False,
             ssl_show_warn=False,
+            # Nested neural queries on chunked indexes can exceed the 10s
+            # default read timeout under load.
+            timeout=60,
+            retry_on_timeout=True,
+            max_retries=2,
         )
         self.index_name = index_name
         self.dataset = ir_datasets.load(dataset_name)

--- a/geniie_lab/services/opensearch/opensearch_client_splade.py
+++ b/geniie_lab/services/opensearch/opensearch_client_splade.py
@@ -35,6 +35,11 @@ class OpenSearchClientSplade:
             verify_certs=False,
             ssl_assert_hostname=False,
             ssl_show_warn=False,
+            # Nested neural queries on chunked indexes can exceed the 10s
+            # default read timeout under load.
+            timeout=60,
+            retry_on_timeout=True,
+            max_retries=2,
         )
         self.index_name = index_name
         self.dataset = ir_datasets.load(dataset_name)


### PR DESCRIPTION
## Summary

Fixes #45 — the OpenSearch clients used opensearch-py's default 10-second read timeout with no retry, and a single slow nested splade query under load crashed an entire 50-topic baseline run with an unhandled `ConnectionTimeout`.

Sets `timeout=60`, `retry_on_timeout=True`, `max_retries=2` on the bm25, splade, and dpr client constructors.

## Verification

Validated across the NTCIR-19 organiser baseline runs: without these settings, one of the first four 50-topic runs crashed on a splade read timeout at topic 43; with them, six subsequent 50–83-topic runs (English Robust 2004 and Japanese NTCIR-1, including concurrent splade sessions) completed with zero timeout failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)