### PR TITLE
Uniform invalid-JSON handling: repair, bounded retry, topic skip

### DIFF
--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -2,6 +2,8 @@
 
 Although the [parameters](../parameters.md) in `ExperimentalSettings` allow researchers to configure many aspects of the experiment, one might wish to control the experiment in depth. Here, we illustrate some directions.
 
+See also: [Invalid JSON handling policy](json_handling.md) — how malformed structured outputs are repaired, retried, and, as a last resort, skipped per topic.
+
 ## Responses
 If you would like to change the format of GII reponses, edit `geniie-lab/response.py`, where structured outputs are defined for LLMs. You can add/remove fields using pydantic format.
 

--- a/docs/advanced/json_handling.md
+++ b/docs/advanced/json_handling.md
@@ -1,0 +1,50 @@
+# Invalid JSON handling policy
+
+LLMs occasionally emit malformed JSON even when the provider advertises
+structured output (observed in practice as escaped closing quotes, raw
+newlines inside strings, markdown fences, and token-limit truncation).
+`geniie-lab` handles every such failure with one uniform, fully logged
+pipeline (issue #13), identical across providers:
+
+1. **Deterministic rule-based repair** (`geniie_lab/services/llm/json_repair.py`).
+   A fixed, ordered list of pure text-transformation rules is applied
+   cumulatively, validating after each step: strip code fences, extract the
+   JSON object from surrounding prose, escape raw newlines inside strings,
+   fix a trailing escaped quote, close unterminated strings/braces. The same
+   raw output always yields the same repaired output. No model round-trip is
+   involved. Applied rules are reported on stderr
+   (`[json-repair] repaired <Model> with rules [...]`), so every rescue is
+   visible in the run log and quantifiable afterwards.
+
+2. **Bounded validation-feedback retry** (max 3 attempts per call). If the
+   output stays invalid after repair — typically *semantic* failures such as
+   enum violations or missing fields, which no text rule can fix — the exact
+   validation error is appended to the outgoing conversation and the call is
+   retried. The failed exchange is kept out of the session memory, so the
+   stored conversation stays identical to a run that succeeded first try.
+   Attempts are reported on stderr and every attempt's tokens are included
+   in the record's `total_token`, keeping cost accounting truthful. This
+   mirrors how large Bedrock experiments were run successfully.
+
+3. **Skip the topic**. After the attempts are exhausted the service raises,
+   the experiment runner records a `[WARNING] ... unrecoverable LLM output`
+   for that topic, stops that topic's pipeline, and continues with the next
+   topic. The experiment as a whole is never lost to a single bad output,
+   and the skip is explicit in the log.
+
+## Reproducibility rationale
+
+Feedback retries are sometimes avoided on reproducibility grounds. We take
+the position that reproducibility in this setting comes from *visibility*,
+not from refusing recovery: LLM inference is already nondeterministic at the
+serving layer (batching, MoE routing) even at `temperature=0`, and the
+FAQ's long-standing advice — resubmit the same instruction until it gets
+through — is itself a retry, performed manually and unlogged. The pipeline
+above automates it with every repair, retry, and skip recorded.
+
+## Interaction with reasoning models
+
+The reasoning trace ("thinking") of reasoning models travels outside the
+structured output channel and can neither corrupt the JSON nor be affected
+by repair. Reasoning-model support (trace capture and length control) is a
+separate feature; the two compose without interaction.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,3 +23,5 @@ We do not currently support a canonical document as input. We will look into thi
 
 ## Are there any tools to analyse the output data?
 No, we decided not to include analytics tools as part of `geniie-lab` since how to analyse response data closely depends on diverse research questions formulated by researchers.
+## What happens when an LLM returns invalid JSON?
+`geniie-lab` handles it automatically, in a fixed order: 1) deterministic rule-based repair (code fences, stray prose, broken escapes, truncation — the same raw output always repairs the same way, no model round-trip), 2) if still invalid, a bounded validation-feedback retry (max 3 attempts; the failed exchange is kept out of session memory and all attempts' tokens are counted in `total_token`), 3) if still invalid, the topic is skipped with a `[WARNING]` in the log and the experiment continues. Every repair, retry, and skip is reported on stderr, so recoveries are visible and quantifiable. See [Invalid JSON handling policy](advanced/json_handling.md) for the full rationale.

--- a/geniie_lab/experiments/agentic_experiment.py
+++ b/geniie_lab/experiments/agentic_experiment.py
@@ -415,7 +415,10 @@ class ExperimentRunner:
                     state.query.start += self.settings.task.serp_size
 
                 stage_runner = self.stage_runners[stage_name]
-                state = stage_runner.run(self.settings, state, llm_service, model, tool, opensearch_client, stage_name)
+                try:
+                    state = stage_runner.run(self.settings, state, llm_service, model, tool, opensearch_client, stage_name)
+                except ValueError as error:
+                    state.error = f"unrecoverable LLM output: {error}"
 
                 if state.error:
                     print(f"[WARNING] in stage '{stage_name}': {state.error}. Stopping pipeline for this topic.", file=sys.stderr)

--- a/geniie_lab/experiments/repetition_experiment.py
+++ b/geniie_lab/experiments/repetition_experiment.py
@@ -361,7 +361,10 @@ class ExperimentRunner:
                     # Run all stages except the last one once, and accumulate memory
                     for stage_name in self.settings.plan[:-1]:
                         stage_runner = self.stage_runners[stage_name]
-                        state = stage_runner.run(self.settings, state, llm_service, model, tool, opensearch_client, repetition=1)
+                        try:
+                            state = stage_runner.run(self.settings, state, llm_service, model, tool, opensearch_client, repetition=1)
+                        except ValueError as error:
+                            state.error = f"unrecoverable LLM output: {error}"
                         if state.error:
                             print(f"[WARNING] in stage '{stage_name}': {state.error}. Stopping pipeline for this topic.", file=sys.stderr)
                             state.error = None
@@ -377,7 +380,10 @@ class ExperimentRunner:
                         # Reset state for the last stage
                         llm_service = self.llm_factory.create_llm_service(model.type)
                         state.memory = base_memory.clone()
-                        state = stage_runner.run(self.settings, state, llm_service, model, tool, opensearch_client, repetition=i+1)
+                        try:
+                            state = stage_runner.run(self.settings, state, llm_service, model, tool, opensearch_client, repetition=i+1)
+                        except ValueError as error:
+                            state.error = f"unrecoverable LLM output: {error}"
                         if state.error:
                             print(f"[WARNING] in stage '{last_stage}' (loop {i+1}): {state.error}. Stopping pipeline for this topic.", file=sys.stderr)
                             state.error = None

--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -358,7 +358,10 @@ class ExperimentRunner:
 
                     for stage_name in self.settings.plan:
                         stage_runner = self.stage_runners[stage_name]
-                        state = stage_runner.run(self.settings, state, llm_service, model, tool, opensearch_client)
+                        try:
+                            state = stage_runner.run(self.settings, state, llm_service, model, tool, opensearch_client)
+                        except ValueError as error:
+                            state.error = f"unrecoverable LLM output: {error}"
                         if state.error:
                             print(f"[WARNING] in stage '{stage_name}': {state.error}. Stopping pipeline for this topic.", file=sys.stderr)
                             state.error = None

--- a/geniie_lab/services/llm/json_repair.py
+++ b/geniie_lab/services/llm/json_repair.py
@@ -1,0 +1,126 @@
+# Deterministic, rule-based repair of malformed JSON emitted by LLMs.
+#
+# Policy (issue #13, refined): repairs are pure functions applied in a fixed
+# order, so a given raw output always yields the same repaired output — no
+# model round-trip is involved at this layer. Callers report which rules
+# fired; outputs that stay invalid after repair go to the caller's bounded
+# feedback-retry loop, and topics whose calls exhaust it are skipped.
+
+import json
+import re
+from typing import Callable, Tuple, Type, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _strip_code_fences(text: str) -> str:
+    """Remove markdown code fences (```json ... ```) around the payload."""
+    return re.sub(r"```[a-zA-Z]*", "", text)
+
+
+def _extract_object(text: str) -> str:
+    """Cut surrounding prose: keep from the first '{' to the last '}'.
+
+    If no '}' exists at all (truncated output), keep from the first '{' to
+    the end so later rules can close the object.
+    """
+    start = text.find("{")
+    if start == -1:
+        return text
+    end = text.rfind("}")
+    return text[start:end + 1] if end > start else text[start:]
+
+
+def _escape_inner_newlines(text: str) -> str:
+    """Escape raw newlines/tabs that appear inside JSON strings."""
+    out, in_string, escaped = [], False, False
+    for char in text:
+        if in_string and char == "\n":
+            out.append("\\n"); continue
+        if in_string and char == "\t":
+            out.append("\\t"); continue
+        out.append(char)
+        if escaped:
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif char == '"':
+            in_string = not in_string
+    return "".join(out)
+
+
+def _fix_trailing_escaped_quote(text: str) -> str:
+    """Fix a string that ends with an escaped quote where it should close.
+
+    Observed in the wild (gpt-oss-120b on vLLM 0.17): '..."reason": "text\\"}'
+    — the closing quote of the last string is escaped, so the string never
+    terminates. Rewrite the final '\\"' before the closing brace to '"'.
+    """
+    return re.sub(r'\\"(\s*[}\]])', r'"\1', text)
+
+
+def _close_unterminated(text: str) -> str:
+    """Close an unterminated final string and any unbalanced braces/brackets
+    (the signature of output truncated by a token limit)."""
+    in_string, escaped = False, False
+    stack = []
+    for char in text:
+        if escaped:
+            escaped = False; continue
+        if char == "\\":
+            escaped = True; continue
+        if char == '"':
+            in_string = not in_string; continue
+        if in_string:
+            continue
+        if char in "{[":
+            stack.append(char)
+        elif char == "}" and stack and stack[-1] == "{":
+            stack.pop()
+        elif char == "]" and stack and stack[-1] == "[":
+            stack.pop()
+    if in_string:
+        text += '"'
+    for opener in reversed(stack):
+        text += "}" if opener == "{" else "]"
+    return text
+
+
+#: Fixed application order — part of the reproducibility contract.
+REPAIR_RULES: list[Tuple[str, Callable[[str], str]]] = [
+    ("strip_code_fences", _strip_code_fences),
+    ("extract_object", _extract_object),
+    ("escape_inner_newlines", _escape_inner_newlines),
+    ("fix_trailing_escaped_quote", _fix_trailing_escaped_quote),
+    ("close_unterminated", _close_unterminated),
+]
+
+
+def repair_and_validate(content: str, response_model: Type[T]) -> Tuple[T, list[str]]:
+    """Validate content against response_model, repairing deterministically.
+
+    Rules are applied cumulatively in REPAIR_RULES order, validating after
+    each step; returns (parsed, applied_rule_names) where applied_rule_names
+    covers every rule applied up to the first success ([] when the content
+    was valid as-is). Raises the last ValidationError/ValueError if the
+    content stays invalid after all rules — the caller decides what happens
+    next (feedback retry, then skipping the topic).
+    """
+    applied: list[str] = []
+    text = content
+    last_error: Exception = ValueError(f"no JSON object found in: {content[:80]!r}")
+    for name, rule in [("as_is", lambda t: t)] + REPAIR_RULES:
+        if name != "as_is":
+            repaired = rule(text)
+            if repaired == text:
+                continue
+            text = repaired
+            applied.append(name)
+        try:
+            json.loads(text)  # syntax first, for a precise error
+            return response_model.model_validate_json(text), applied
+        except (ValidationError, ValueError) as error:
+            last_error = error
+    raise last_error

--- a/geniie_lab/services/llm/openai_compatible.py
+++ b/geniie_lab/services/llm/openai_compatible.py
@@ -1,5 +1,6 @@
 # Standard library
 import json
+import sys
 from typing import Callable, Tuple, Type, TypeVar
 
 # Third-party libraries
@@ -11,6 +12,7 @@ import tiktoken
 from geniie_lab.dataclasses.description import ModelDescription
 from geniie_lab.dataclasses.instruction import Instruction
 from geniie_lab.memory import ConversationHistory
+from geniie_lab.services.llm.json_repair import repair_and_validate
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -22,9 +24,15 @@ class OpenAICompatibleLLMService:
     or a pre-built client such as AzureOpenAI) and in whether tiktoken should
     look up a model-specific encoding. The provider registry lives in
     llm_service_factory.
+
+    Invalid structured output is handled uniformly (issue #13): deterministic
+    rule-based repair first (json_repair module), then a bounded
+    validation-feedback retry, then a ValueError that the experiment runners
+    turn into skipping the topic. Repairs and retries are reported on stderr
+    so every recovery is visible in the run log.
     """
 
-    #: Attempts per call when schema_via_prompt validation fails.
+    #: Attempts per call when validation fails after repair.
     MAX_SCHEMA_RETRIES = 3
 
     def __init__(
@@ -41,7 +49,7 @@ class OpenAICompatibleLLMService:
         # response_format for open-weight models: strict grammars loop on
         # whitespace and non-strict ones leak stray tokens before the JSON.
         # When set, send the schema in the prompt with json_object mode and
-        # validate the response ourselves instead of using parse().
+        # validate the response ourselves instead.
         self._schema_via_prompt = schema_via_prompt
 
     def generate(
@@ -52,46 +60,12 @@ class OpenAICompatibleLLMService:
         response_model: Type[T],
     ) -> Tuple[T, int]:
         """Ask the model to respond to the instruction as a response_model."""
-        call = (self._call_llm_with_prompted_schema if self._schema_via_prompt
-                else self._call_llm_with_pydantic_response)
-        return call(
+        return self._call_llm_with_repair(
             model.name, model.token_length, model.temperature, model.top_p,
             memory, instruction, response_model,
         )
 
-    def _call_llm_with_pydantic_response(
-        self,
-        model: str,
-        token_length: int,
-        temperature: float,
-        top_p: float,
-        memory: ConversationHistory,
-        instruction: Instruction,
-        response_model: Type[T]
-    ) -> Tuple[T, int]:
-
-        memory.add_user_message(instruction.generate())
-        # Pass roles through unchanged: the system prompt and previous assistant
-        # turns must not be re-sent as user messages.
-        messages: list[dict[str, str]] = memory.get_messages(tokenizer=self.get_tokenizer(model), max_tokens=token_length)
-        completion = self.client.beta.chat.completions.parse(
-            model=model,
-            messages=messages,
-            response_format=response_model,
-            temperature=temperature,
-            top_p=top_p,
-        )
-        parsed_response = completion.choices[0].message.parsed
-        if parsed_response is None:
-            raise ValueError(f"LLM returned empty parsed object for {response_model.__name__}.")
-        memory.add_assistant_response(completion.choices[0].message.to_json())
-
-        usage = getattr(completion, "usage", None)
-        total_token = getattr(usage, "total_tokens", 0) or 0
-
-        return parsed_response, total_token
-
-    def _call_llm_with_prompted_schema(
+    def _call_llm_with_repair(
         self,
         model: str,
         token_length: int,
@@ -102,30 +76,49 @@ class OpenAICompatibleLLMService:
         response_model: Type[T]
     ) -> Tuple[T, int]:
         tokenizer = self.get_tokenizer(model)
-        schema_suffix = (
-            "\n\nRespond with ONLY a JSON object that conforms to this JSON schema:\n"
-            + json.dumps(response_model.model_json_schema())
-        )
-        # Store only the plain instruction in session memory so bedrock
-        # conversations stay identical to providers that take the schema
-        # out-of-band; the schema rides along on the outgoing copy only.
+
+        # Store only the plain instruction in session memory: with
+        # schema_via_prompt the schema rides along on the outgoing copy only,
+        # so conversations stay identical across providers.
         memory.add_user_message(instruction.generate())
+        # Pass roles through unchanged: the system prompt and previous
+        # assistant turns must not be re-sent as user messages.
         messages: list[dict[str, str]] = memory.get_messages(tokenizer=tokenizer, max_tokens=token_length)
-        messages = messages[:-1] + [
-            {**messages[-1], "content": messages[-1]["content"] + schema_suffix}
-        ]
-        # The schema suffix exists only to work around the provider's broken
-        # response_format; exclude it from the reported count so bedrock
-        # sessions are token-comparable with other providers. The deduction
-        # uses the trimming tokenizer, so it is approximate.
-        schema_tokens = tokenizer(schema_suffix)
+
+        schema_tokens = 0
+        if self._schema_via_prompt:
+            schema_suffix = (
+                "\n\nRespond with ONLY a JSON object that conforms to this JSON schema:\n"
+                + json.dumps(response_model.model_json_schema())
+            )
+            messages = messages[:-1] + [
+                {**messages[-1], "content": messages[-1]["content"] + schema_suffix}
+            ]
+            # The schema suffix exists only to work around the provider's
+            # broken response_format; exclude it from the reported count so
+            # sessions stay token-comparable with providers that take the
+            # schema out-of-band. Approximate (trimming tokenizer).
+            schema_tokens = tokenizer(schema_suffix)
+            response_format = {"type": "json_object"}
+        else:
+            # strict matches what the SDK's parse() helper sent before the
+            # repair rewrite, so grammar enforcement stays as tight as before.
+            response_format = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": response_model.__name__,
+                    "schema": response_model.model_json_schema(),
+                    "strict": True,
+                },
+            }
+
         total_token = 0
         last_error: Exception | None = None
-        for _ in range(self.MAX_SCHEMA_RETRIES):
+        for attempt in range(self.MAX_SCHEMA_RETRIES):
             completion = self.client.chat.completions.create(
                 model=model,
                 messages=messages,
-                response_format={"type": "json_object"},
+                response_format=response_format,
                 temperature=temperature,
                 top_p=top_p,
             )
@@ -134,11 +127,14 @@ class OpenAICompatibleLLMService:
             total_token += max(0, call_tokens - schema_tokens)
             content = completion.choices[0].message.content or ""
             try:
-                parsed_response = self._parse_lenient(content, response_model)
+                parsed_response, repairs = repair_and_validate(content, response_model)
             except (ValidationError, ValueError) as error:
-                # Feedback retry: keep the failed exchange out of the session
-                # memory but show it to the model so the next attempt differs.
+                # Bounded feedback retry: keep the failed exchange out of the
+                # session memory but show it to the model so the next attempt
+                # differs. Reported so the recovery is visible in the run log.
                 last_error = error
+                print(f"[json-repair] attempt {attempt + 1}/{self.MAX_SCHEMA_RETRIES} "
+                      f"invalid {response_model.__name__}: {error}", file=sys.stderr)
                 messages = messages + [
                     {"role": "assistant", "content": content},
                     {"role": "user", "content":
@@ -146,30 +142,15 @@ class OpenAICompatibleLLMService:
                         "Respond again with ONLY a valid JSON object for the schema."},
                 ]
                 continue
+            if repairs:
+                print(f"[json-repair] repaired {response_model.__name__} "
+                      f"with rules {repairs}", file=sys.stderr)
             memory.add_assistant_response(completion.choices[0].message.to_json())
             return parsed_response, total_token
         raise ValueError(
             f"LLM response failed {response_model.__name__} validation after "
             f"{self.MAX_SCHEMA_RETRIES} attempts: {last_error}"
         )
-
-    @staticmethod
-    def _parse_lenient(content: str, response_model: Type[T]) -> T:
-        """Validate content, tolerating stray tokens around the JSON object.
-
-        Providers without a real schema grammar can emit prefixes such as
-        "1,{...}" or "{ {...}" around an otherwise valid object; try each
-        "{"-suffix of the content until one validates.
-        """
-        end = content.rfind("}") + 1
-        starts = [i for i, char in enumerate(content[:end]) if char == "{"]
-        last_error: Exception = ValueError(f"no JSON object found in: {content[:80]!r}")
-        for start in starts:
-            try:
-                return response_model.model_validate_json(content[start:end])
-            except ValidationError as error:
-                last_error = error
-        raise last_error
 
     def get_tokenizer(self, model_name: str) -> Callable[[str], int]:
         if self._tiktoken_by_model:

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -1,0 +1,62 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from geniie_lab.services.llm.json_repair import repair_and_validate
+
+
+class Answer(BaseModel):
+    crossings: int
+    plan: str
+
+
+def test_valid_json_passes_untouched():
+    parsed, applied = repair_and_validate('{"crossings": 7, "plan": "go"}', Answer)
+    assert parsed.crossings == 7
+    assert applied == []
+
+
+def test_strips_code_fences_and_prose():
+    content = 'Here is the answer:\n```json\n{"crossings": 7, "plan": "go"}\n```\nDone.'
+    parsed, applied = repair_and_validate(content, Answer)
+    assert parsed.plan == "go"
+    assert "extract_object" in applied
+
+
+def test_fixes_trailing_escaped_quote():
+    # Real-world shape observed from gpt-oss-120b on vLLM 0.17.
+    content = '{"crossings": 7, "plan": "take the goat\\"}'
+    parsed, applied = repair_and_validate(content, Answer)
+    assert parsed.plan == "take the goat"
+    assert "fix_trailing_escaped_quote" in applied
+
+
+def test_closes_truncated_output():
+    content = '{"crossings": 7, "plan": "take the goat'
+    parsed, applied = repair_and_validate(content, Answer)
+    assert parsed.plan == "take the goat"
+    assert "close_unterminated" in applied
+
+
+def test_escapes_raw_newlines_inside_strings():
+    content = '{"crossings": 7, "plan": "1. goat\n2. return"}'
+    parsed, applied = repair_and_validate(content, Answer)
+    assert parsed.plan == "1. goat\n2. return"
+    assert "escape_inner_newlines" in applied
+
+
+def test_semantic_error_is_not_repairable():
+    # Syntactically fine, semantically wrong: repair must not mask it.
+    with pytest.raises(ValidationError):
+        repair_and_validate('{"crossings": "many", "plan": 3}', Answer)
+
+
+def test_no_json_at_all_raises():
+    with pytest.raises((ValidationError, ValueError)):
+        repair_and_validate('I cannot answer that.', Answer)
+
+
+def test_determinism():
+    content = 'noise {"crossings": 7, "plan": "go\\"}'
+    parsed, applied = repair_and_validate(content, Answer)
+    assert all(r == (parsed, applied) for r in
+               [repair_and_validate(content, Answer) for _ in range(3)])

--- a/tests/test_llm_services.py
+++ b/tests/test_llm_services.py
@@ -1,47 +1,52 @@
 from types import SimpleNamespace
 
+import pytest
+
 from geniie_lab.dataclasses.description import ModelDescription
 from geniie_lab.dataclasses.instruction import QueryReFormulationInstruction
 from geniie_lab.memory import ConversationHistory
 from geniie_lab.response import Query
 from geniie_lab.services.llm.openai_compatible import OpenAICompatibleLLMService
 
+VALID_QUERY_JSON = '{"query": "q", "start": 0, "size": 10, "reason": "r"}'
+
 
 class StubClient:
-    """Captures the kwargs of beta.chat.completions.parse and returns a
-    canned parsed completion."""
+    """Captures the kwargs of chat.completions.create and returns canned
+    message contents, one per call (the last repeats)."""
 
-    def __init__(self, parsed):
+    def __init__(self, *contents):
         self.calls = []
+        self._contents = list(contents)
 
-        def parse(**kwargs):
+        def create(**kwargs):
             self.calls.append(kwargs)
-            message = SimpleNamespace(parsed=parsed, to_json=lambda: '{"canned": true}')
+            content = self._contents.pop(0) if len(self._contents) > 1 else self._contents[0]
+            message = SimpleNamespace(content=content, to_json=lambda: '{"canned": true}')
             return SimpleNamespace(
                 choices=[SimpleNamespace(message=message)],
                 usage=SimpleNamespace(total_tokens=99),
             )
 
-        self.beta = SimpleNamespace(
-            chat=SimpleNamespace(completions=SimpleNamespace(parse=parse))
-        )
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=create))
 
 
-def test_call_preserves_roles_and_updates_memory():
-    parsed = Query(query="q", start=0, size=10, reason="r")
-    stub = StubClient(parsed)
-    service = OpenAICompatibleLLMService(client=stub, tiktoken_by_model=False)
-
+def _service_call(stub, **service_kwargs):
+    service = OpenAICompatibleLLMService(client=stub, tiktoken_by_model=False, **service_kwargs)
     memory = ConversationHistory(system_role=None, system_prompt="be helpful")
     memory.add_user_message("earlier user turn")
     memory.add_assistant_response("earlier assistant turn")
-
     instruction = QueryReFormulationInstruction(instruction="reformulate")
     model = ModelDescription(type="openai", name="some-model", token_length=100000,
                              temperature=0.0, top_p=1.0)
-    response, total_token = service.generate(model, memory, instruction, Query)
+    return service.generate(model, memory, instruction, Query), memory
 
-    assert response is parsed
+
+def test_call_preserves_roles_and_updates_memory():
+    stub = StubClient(VALID_QUERY_JSON)
+    (response, total_token), memory = _service_call(stub)
+
+    assert response == Query(query="q", start=0, size=10, reason="r")
     assert total_token == 99
 
     # B4: roles must be passed through unchanged -- system prompt first, and
@@ -51,13 +56,57 @@ def test_call_preserves_roles_and_updates_memory():
     assert sent[0]["content"] == "be helpful"
     assert sent[2] == {"role": "assistant", "content": "earlier assistant turn"}
 
-    # Generation parameters are forwarded.
+    # Generation parameters and the out-of-band schema are forwarded.
     assert stub.calls[0]["model"] == "some-model"
     assert stub.calls[0]["temperature"] == 0.0
-    assert stub.calls[0]["response_format"] is Query
+    assert stub.calls[0]["response_format"]["type"] == "json_schema"
+    assert stub.calls[0]["response_format"]["json_schema"]["name"] == "Query"
 
     # Memory gains the instruction (user) and the raw completion (assistant).
     history = memory.get_all_messages()
     assert history[-2]["role"] == "user"
     assert "reformulate" in history[-2]["content"]
     assert history[-1] == {"role": "assistant", "content": '{"canned": true}'}
+
+
+def test_schema_via_prompt_appends_schema_to_outgoing_copy_only():
+    stub = StubClient(VALID_QUERY_JSON)
+    (response, _), memory = _service_call(stub, schema_via_prompt=True)
+
+    assert response.query == "q"
+    assert stub.calls[0]["response_format"] == {"type": "json_object"}
+    # Schema rides on the outgoing message; session memory keeps the plain one.
+    assert "JSON schema" in stub.calls[0]["messages"][-1]["content"]
+    assert "JSON schema" not in memory.get_all_messages()[-2]["content"]
+
+
+def test_repaired_output_needs_no_second_call():
+    # Real failure shape (gpt-oss on vLLM 0.17): escaped closing quote.
+    broken = '{"query": "q", "start": 0, "size": 10, "reason": "big fish\\"}'
+    stub = StubClient(broken)
+    (response, total_token), _ = _service_call(stub)
+
+    assert response.reason == "big fish"
+    assert len(stub.calls) == 1  # rule-based repair, no model round-trip
+    assert total_token == 99
+
+
+def test_feedback_retry_after_unrepairable_output():
+    stub = StubClient('not json at all', VALID_QUERY_JSON)
+    (response, total_token), _ = _service_call(stub)
+
+    assert response.query == "q"
+    assert len(stub.calls) == 2
+    # The retry conversation contains the failed output and the feedback.
+    retry_messages = stub.calls[1]["messages"]
+    assert retry_messages[-2] == {"role": "assistant", "content": "not json at all"}
+    assert "not valid" in retry_messages[-1]["content"]
+    # Tokens from both attempts are accounted.
+    assert total_token == 198
+
+
+def test_exhausted_retries_raise_for_topic_skip():
+    stub = StubClient('not json at all')
+    with pytest.raises(ValueError, match="after 3 attempts"):
+        _service_call(stub)
+    assert len(stub.calls) == 3


### PR DESCRIPTION
Fixes #13.

Invalid structured output is now handled identically on both call paths (out-of-band strict `json_schema`, and schema-in-prompt for providers with broken grammar compilers):

1. **Deterministic rule-based repair** (`geniie_lab/services/llm/json_repair.py`) — a fixed, ordered list of pure text rules (strip fences, extract object, escape inner newlines, fix trailing escaped quote, close truncation), validated after each step; the same raw output always repairs the same way, no model round-trip. Applied rules are reported on stderr.
2. **Bounded validation-feedback retry** (max 3) — the exact validation error is fed back; the failed exchange is kept out of session memory so stored conversations stay identical to first-try runs; every attempt's tokens are counted in `total_token`. This is the loop that ran large Bedrock experiments solidly.
3. **Skip the topic, not the experiment** — after exhaustion the service raises and the runners convert it into the existing `state.error` warn-and-continue path.

The SDK `parse()` helper is replaced by `create()` + our own validation (keeping `strict: true` for schema parity) so the repair layer can see raw content. Two distinct failure classes motivate the layers: behavioural non-compliance (feedback-responsive) and serving-backend grammar bugs such as vLLM 0.17's escaped-quote fault (rule-repairable — it occurs *with* strict grammars).

Policy documented in `docs/advanced/json_handling.md` + an FAQ entry, including the reproducibility rationale (visibility over refusal: every repair/retry/skip is logged) and the non-interaction with reasoning-trace capture.

**Verification**: 30/30 tests (8 new repair-rule tests incl. determinism; service tests rewritten for the unified path); live gpt-oss-120b smoke run (query+ranking+click) clean first-try under strict; injected escape/prose/unfixable faults exercised repair, retry, and skip respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)