### PR TITLE
Support sub topics for diversity/intent tasks (#51)

### DIFF
--- a/geniie_lab/dataclasses/topic.py
+++ b/geniie_lab/dataclasses/topic.py
@@ -73,6 +73,77 @@ class TitleDescriptionNarrativeTopic(BaseTopic):
 class FullTopic(TitleDescriptionNarrativeTopic):
     pass
 
+# Subtopic-bearing topics for diversity/intent tasks (issue #51).
+#
+# Subtopics are the evaluation ground truth of diversity collections; they are
+# NEVER rendered into prompts. __str__ (what stages inject into the LLM
+# context) shows only the searcher-visible fields, with no disclosure option.
+
+@dataclass
+class Subtopic:
+    number: str
+    text: str
+    probability: Optional[float] = None   # NTCIR intent probability
+    intent_type: Optional[str] = None     # NTCIR-10 'nav' / 'inf'
+
+@dataclass
+class SubtopicTopic(BaseTopic):
+    """Base for topics that carry subtopics. Subtopics are held for logging
+    and evaluation only; rendering exposes just the searcher-visible fields."""
+    subtopics: List[Subtopic] = field(default_factory=list)
+
+    def __str__(self):
+        return f"- **Title**: {self.title}"
+
+@dataclass
+class TrecDiversityTopic(SubtopicTopic):
+    """TREC Web Track diversity topic (2009-2012): query text, description,
+    topic type (faceted/ambiguous), and the judged subtopics.
+
+    Rendering is query-only, matching the track protocol: participants were
+    given only the query field; the description (assessor-facing) and the
+    subtopics were released after run submission (TREC 2009 Web Track
+    overview, section 2). Both are kept as data for logging and analysis."""
+    description: Optional[str] = None
+    topic_type: Optional[str] = None
+
+    @classmethod
+    def from_ir_datasets(cls, raw) -> "TrecDiversityTopic":
+        description = getattr(raw, "description", None)
+        return cls(
+            id=raw.query_id,
+            title=" ".join(raw.query.split()),
+            description=" ".join(description.split()) if description else None,
+            topic_type=getattr(raw, "type", None),
+            subtopics=[
+                Subtopic(number=str(getattr(s, "number", i + 1)),
+                         text=" ".join(s.text.split()))
+                for i, s in enumerate(raw.subtopics)
+            ],
+        )
+
+@dataclass
+class NtcirIntentTopic(SubtopicTopic):
+    """NTCIR INTENT-1/2 Japanese Document Ranking topic: the searcher sees the
+    query string alone; intents carry probabilities and (INTENT-2) nav/inf
+    types for evaluation."""
+
+    @classmethod
+    def from_ir_datasets(cls, raw) -> "NtcirIntentTopic":
+        return cls(
+            id=raw.query_id,
+            title=raw.query,
+            subtopics=[
+                Subtopic(
+                    number=str(s.number),
+                    text=getattr(s, "description", ""),
+                    probability=getattr(s, "probability", None),
+                    intent_type=getattr(s, "intent_type", None) or None,
+                )
+                for s in raw.subtopics
+            ],
+        )
+
 T = TypeVar("T", bound=BaseTopic)
 
 @dataclass

--- a/tests/test_subtopic_topics.py
+++ b/tests/test_subtopic_topics.py
@@ -1,0 +1,97 @@
+"""Tests for the subtopic-bearing topic classes (issue #51).
+
+Raw query objects are synthetic namedtuples mirroring the ir_datasets shapes
+(TREC Web Track diversity; NTCIR INTENT registrations) -- no collection data.
+"""
+
+from collections import namedtuple
+
+from geniie_lab.dataclasses.topic import (
+    NtcirIntentTopic,
+    Subtopic,
+    SubtopicTopic,
+    TrecDiversityTopic,
+)
+
+TrecSubtopic = namedtuple("TrecSubtopic", ["number", "text", "type"])
+TrecWebTrackQuery = namedtuple(
+    "TrecWebTrackQuery", ["query_id", "query", "description", "type", "subtopics"]
+)
+IntentSubtopic = namedtuple("IntentSubtopic", ["number", "probability", "description"])
+Intent2Subtopic = namedtuple(
+    "Intent2Subtopic", ["number", "probability", "intent_type", "description"]
+)
+IntentQuery = namedtuple("IntentQuery", ["query_id", "query", "subtopics"])
+
+
+def make_trec_raw():
+    return TrecWebTrackQuery(
+        query_id="20",
+        query="defender",
+        description="Find information about the Land Rover Defender sport-utility vehicle.",
+        type="ambiguous",
+        subtopics=(
+            TrecSubtopic(number="1", text="Land Rover Defender SUV", type="inf"),
+            TrecSubtopic(number="2", text="Defender arcade game", type="nav"),
+        ),
+    )
+
+
+def make_intent_raw():
+    return IntentQuery(
+        query_id="0101",
+        query="日露戦争",  # a Japanese query string
+        subtopics=(
+            IntentSubtopic(number="1", probability=0.16, description="cause"),
+            Intent2Subtopic(number="2", probability=0.14, intent_type="inf", description="timeline"),
+        ),
+    )
+
+
+class TestTrecDiversityTopic:
+    def test_field_mapping(self):
+        topic = TrecDiversityTopic.from_ir_datasets(make_trec_raw())
+        assert topic.id == "20"
+        assert topic.title == "defender"
+        assert topic.topic_type == "ambiguous"
+        assert isinstance(topic, SubtopicTopic)
+        assert [s.number for s in topic.subtopics] == ["1", "2"]
+        assert topic.subtopics[0].text == "Land Rover Defender SUV"
+        assert topic.subtopics[0].probability is None
+
+    def test_rendering_is_query_only_per_track_protocol(self):
+        # TREC 2009 overview, sec. 2: participants received only the query
+        # field; description and subtopics must never reach the prompt.
+        topic = TrecDiversityTopic.from_ir_datasets(make_trec_raw())
+        rendered = str(topic)
+        assert rendered == "- **Title**: defender"
+        assert "sport-utility" not in rendered
+        for subtopic in topic.subtopics:
+            assert subtopic.text not in rendered
+
+    def test_description_kept_as_data(self):
+        topic = TrecDiversityTopic.from_ir_datasets(make_trec_raw())
+        assert topic.description.startswith("Find information")
+
+    def test_whitespace_normalised(self):
+        raw = make_trec_raw()._replace(query="  defender \n ")
+        topic = TrecDiversityTopic.from_ir_datasets(raw)
+        assert topic.title == "defender"
+
+
+class TestNtcirIntentTopic:
+    def test_field_mapping(self):
+        topic = NtcirIntentTopic.from_ir_datasets(make_intent_raw())
+        assert topic.id == "0101"
+        assert topic.title == "日露戦争"
+        assert isinstance(topic, SubtopicTopic)
+        assert topic.subtopics[0] == Subtopic(
+            number="1", text="cause", probability=0.16, intent_type=None
+        )
+        assert topic.subtopics[1].intent_type == "inf"
+
+    def test_rendering_is_query_only(self):
+        topic = NtcirIntentTopic.from_ir_datasets(make_intent_raw())
+        assert str(topic) == "- **Title**: 日露戦争"
+        for subtopic in topic.subtopics:
+            assert subtopic.text not in str(topic)


### PR DESCRIPTION
Closes #51.

Adds subtopic-bearing topic classes so diversity/intent collections load through `topicset`:

- `Subtopic` — number, text, optional probability and nav/inf intent type (one shape for TREC subtopics and NTCIR intents)
- `SubtopicTopic(BaseTopic)` — shared base; subtopics held for logging/evaluation only
- `TrecDiversityTopic` — TREC Web Track 2009-2012 diversity topics (query, description, faceted/ambiguous type)
- `NtcirIntentTopic` — NTCIR INTENT-1/2 topics (query only, intents with probabilities and INTENT-2 nav/inf types)

Rendering (`__str__`, what stages inject into prompts) is deliberately query-only with no disclosure option, matching the track protocol — the TREC 2009 overview (sec. 2) states participants received only the query field, with descriptions and subtopics released after run submission. Whitespace in the TREC XML fields is normalised on load.

Usage: `TopicDescription(name="clueweb09/catb/trec-web-2009/diversity", type="ir_datasets", topic_class=TrecDiversityTopic)`.

Tests: `tests/test_subtopic_topics.py` (synthetic raws only, no collection data) covering field mapping, prompt non-leakage, and whitespace normalisation; full suite 41/41. Both classes also verified against the real ir_datasets TREC and INTENT registrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)