### PR TITLE
Clicks.ranking_list: plain integers (drop Groq string-pattern workaround)

### DIFF
--- a/geniie_lab/response.py
+++ b/geniie_lab/response.py
@@ -53,21 +53,16 @@ class Clicks(BaseModel):
         title="ranking_list",
         description=(
             "The ranking numbers of the documents in the result to examine the full text. "
-            'Each element is one ranking number as a numeric string, e.g. ["2", "5", "7"]. '
+            "Each element is one ranking number, e.g. [2, 5, 7]. "
             "Use ranking numbers, not document IDs."
         ),
-        # Prevention layer, from strongest to weakest:
-        #  - "type": "string"  — Groq's constrained decoder drops commas between
-        #    bare integers ([2, 9] arrives as [29]); quoted items force separators.
-        #  - "pattern": "^[0-9]{1,3}$" — grammar-enforcing providers can then ONLY
-        #    emit digit strings, making document IDs ("LA043090-0036") impossible.
-        #  - the description's example and "not document IDs" steer providers that
-        #    enforce schemas loosely (local vLLM).
-        # pydantic coerces each "2" back to int, so ranking_list stays List[int]
-        # for all downstream code.
-        json_schema_extra=lambda schema: schema.update(
-            {"items": {"type": "string", "pattern": "^[0-9]{1,3}$"}}
-        ),
+        # Plain integer items. A string coercion with a digit pattern used to
+        # live here as a Groq workaround (its decoder dropped commas between
+        # bare integers). Groq is no longer used, and the string grammar broke
+        # gpt-oss on vLLM: guided decoding blocked the model's natural `[1`
+        # continuation and it degenerated to an empty (but valid) list, i.e.
+        # silent zero-click sessions. Integer typing also keeps document-ID
+        # strings impossible under grammar-enforcing providers.
     )
     reason: str = Field(
         ...,


### PR DESCRIPTION
Removes the string-coercion `json_schema_extra` from `Clicks.ranking_list`, making the advertised schema plain `List[int]`.

Why: the string pattern was a Groq workaround (its decoder dropped commas between bare integers), and Groq is no longer used. Under vLLM's grammar-constrained decoding the string grammar actively harms gpt-oss: the reasoning trace decides e.g. "output [1]", but after `"ranking_list": [` every non-quote token is masked, and the model resolves the conflict by closing an empty — valid — list. Result: sessions silently record zero clicks, the relevance stage never runs, and the log misreads as an over-cautious model. Observed and reproduced 2026-08-09 on gpt-oss-120b / vLLM with thinking logs.

Integer typing retains the useful property that grammar-enforcing providers cannot emit document-ID strings. The description example switches to `[2, 5, 7]` accordingly. Downstream code is unchanged (`ranking_list` was already `List[int]` after pydantic coercion); tests 41/41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)