### PR TITLE
Register subtopic topic classes in ExperimentRunner.topic_list_map (#51)

### DIFF
--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -13,6 +13,8 @@ from geniie_lab.dataclasses.topic import (
     TitleDescriptionTopic,
     TitleNarrativeTopic,
     TitleOnlyTopic,
+    TrecDiversityTopic,
+    NtcirIntentTopic,
     TopicList,
     BaseTopic
 )
@@ -293,6 +295,8 @@ class ExperimentRunner:
             TitleNarrativeTopic: TopicList[TitleNarrativeTopic],
             TitleDescriptionNarrativeTopic: TopicList[TitleDescriptionNarrativeTopic],
             FullTopic: TopicList[FullTopic],  # Optional, same as above
+            TrecDiversityTopic: TopicList[TrecDiversityTopic],
+            NtcirIntentTopic: TopicList[NtcirIntentTopic],
         }
 
         self.llm_factory = LLMServiceFactory()


### PR DESCRIPTION
Follow-up to #52: the merge caught the topic classes but not this later commit on the same branch. Without it, `ExperimentRunner` raises `KeyError: TrecDiversityTopic` when a diversity topicset is configured — the runner's `topic_list_map` must know the new classes. One 4-line change, verified by running a full session experiment with `TrecDiversityTopic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)