### PR TITLE
feat(session): add click-state field to SearchResultItem

### DIFF
--- a/docs/experiments/common_settings.md
+++ b/docs/experiments/common_settings.md
@@ -189,10 +189,12 @@ Each stage has a name such as `query`, `ranking`, or `click`, and you can config
 - `topic_ids`: Define subset of topics in a slice manner. For example, `topic_ids="2:5"` will use from the 2nd to 5th topics in the dataset. Default: `None`
 - `full_log`: Define whether or not a full interaction log with LLMs is produced at the end of each topic. Useful for debugging purpose. Make sure to catch STDERR to save the full log. Default: `False`. Alternatively, you can set the log level to `DEBUG` in the logger defined at the beginning of the runner scripts in `scripts` folder.
 - `custom_settings`: A variable to store any arbitary strings to note for an experiment (e.g., specific parameter settings). It will be included in the outputs but not to present to GII. Default: `None`
+- `mark_visited_results`: Define whether the search results shown to GII indicate the documents it has already opened earlier in the same session, in the way a web browser colours visited links. When `True`, such a result is rendered with `visited=True`; results not yet opened are rendered exactly as before, so only the visited ones carry a cue. Visits are recorded at click time and reset between topics. Set to `False` to reproduce runs made before this setting existed, since it changes what GII sees. Default: `True`
 
 ```python
     max_topics=1,
     topic_ids="2:5",
     full_log=False,
-    custom_settings=None
+    custom_settings=None,
+    mark_visited_results=True
 ```

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -41,3 +41,4 @@ The following parameters can be configured via `ExperimentSettings` in the runne
 |Other|All|`topic_ids`|1:10|Range of topic positions to run, as `start:end` (1-based, inclusive). Useful to resume an experiment from a particular topic. `None` means all topics (Default: `None`)|
 |Other|All|`full_log`|False|Toggle the outputs of full interaction log with LLMs.|
 |Other|All|`custom_settings`|None|Arbitrary strings to note for an experiment (e.g., specific parameter settings)|
+|Other|Session|`mark_visited_results`|True|Mark search results GII already opened in this session with `visited=True`, like a browser's visited links. Set to `False` to reproduce runs made before this existed (Default: `True`)|

--- a/geniie_lab/dataclasses/serp.py
+++ b/geniie_lab/dataclasses/serp.py
@@ -16,6 +16,16 @@ class SearchResultItem(DataClassJsonMixin):
     # repr=False keeps it out of the SERP rendered into LLM instructions:
     # the simulated searcher must not see engine scores.
     score: float = field(default=0.0, repr=False)
+    visited: bool = False
+
+    def __repr__(self) -> str:
+        # Only visited results carry the attribute, like a browser's visited
+        # link colour: an unmarked SERP renders exactly as it did before.
+        fields = (f"ranking={self.ranking!r}, docid={self.docid!r}, "
+                  f"title={self.title!r}, snippet={self.snippet!r}")
+        if self.visited:
+            fields += f", visited={self.visited!r}"
+        return f"{self.__class__.__qualname__}({fields})"
 
 @dataclass_json
 @dataclass

--- a/geniie_lab/dataclasses/setting.py
+++ b/geniie_lab/dataclasses/setting.py
@@ -1,6 +1,6 @@
 # Standard library
 from dataclasses import dataclass, field
-from typing import Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Set, Union
 
 # Local application imports
 from geniie_lab.dataclasses.serp import Serp, FullText
@@ -46,6 +46,8 @@ class ExperimentSettings:
     max_actions: Optional[int] = None
     custom_settings: Optional[str] = None
     full_log: Optional[bool] = False
+    # Set False to reproduce runs made before visited marking existed.
+    mark_visited_results: bool = True
 
 @dataclass
 class ExperimentState:
@@ -60,6 +62,7 @@ class ExperimentState:
     error: Optional[str] = None
     action_num: Optional[int] = 1
     next_action: Optional[Action] = None
+    visited_docids: Set[str] = field(default_factory=set)
 
 @dataclass
 class Error:

--- a/geniie_lab/experiments/agentic_experiment.py
+++ b/geniie_lab/experiments/agentic_experiment.py
@@ -136,6 +136,14 @@ class ClickStage:
             return state
 
         print("\n--- Running: Click Stage ---", file=sys.stderr)
+        # Marked here rather than when the SERP is built: CLICK_DOCUMENT runs
+        # without a ranking stage, so the same SERP is rendered again and must
+        # show the clicks made since the last rendering.
+        if settings.mark_visited_results:
+            for item in state.serp.results:
+                if item.docid in state.visited_docids:
+                    item.visited = True
+
         instruction_text = self.config.instruction or self.DEFAULT_INSTRUCTION
         click_instruction = ClickInstruction(instruction=instruction_text, serp=state.serp)
 
@@ -143,6 +151,12 @@ class ClickStage:
         thinking_token = llm_service.get_tokenizer(model.name)(thinking) if thinking else None
         if not self.config.log_thinking:
             thinking = None
+
+        # Marked at click time, not read time: out-of-range indices are left
+        # for the judgement stage, which already reports them as an error.
+        for click_index in state.clicks.ranking_list:
+            if 1 <= click_index <= len(state.serp.results):
+                state.visited_docids.add(state.serp.results[click_index - 1].docid)
 
         output = ClickExperimentOutput(
             session_name=settings.name,

--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -92,11 +92,6 @@ class RankingStage:
         state.serp = opensearch_client.search_index_with_snippets(query_text, start=start_offset, size=settings.task.serp_size)
         state.docids = [item.docid for item in state.serp.results] if state.serp and state.serp.results else []
 
-        if settings.mark_visited_results and state.serp and state.serp.results:
-            for item in state.serp.results:
-                if item.docid in state.visited_docids:
-                    item.visited = True
-
         dataset = ir_datasets.load(settings.topicset.name)
         if callable(dataset):
             dataset = dataset()
@@ -142,6 +137,14 @@ class ClickStage:
             return state
 
         print("\n--- Running: Click Stage ---", file=sys.stderr)
+        # Marked here rather than when the SERP is built: the same SERP can be
+        # rendered more than once, and each rendering must show the clicks made
+        # since the last one.
+        if settings.mark_visited_results:
+            for item in state.serp.results:
+                if item.docid in state.visited_docids:
+                    item.visited = True
+
         instruction_text = self.config.instruction or self.DEFAULT_INSTRUCTION
         click_instruction = ClickInstruction(instruction=instruction_text, serp=state.serp)
 

--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -92,6 +92,11 @@ class RankingStage:
         state.serp = opensearch_client.search_index_with_snippets(query_text, start=start_offset, size=settings.task.serp_size)
         state.docids = [item.docid for item in state.serp.results] if state.serp and state.serp.results else []
 
+        if settings.mark_visited_results and state.serp and state.serp.results:
+            for item in state.serp.results:
+                if item.docid in state.visited_docids:
+                    item.visited = True
+
         dataset = ir_datasets.load(settings.topicset.name)
         if callable(dataset):
             dataset = dataset()
@@ -144,6 +149,12 @@ class ClickStage:
         thinking_token = llm_service.get_tokenizer(model.name)(thinking) if thinking else None
         if not self.config.log_thinking:
             thinking = None
+
+        # Marked at click time, not read time: out-of-range indices are left
+        # for the judgement stage, which already reports them as an error.
+        for click_index in state.clicks.ranking_list:
+            if 1 <= click_index <= len(state.serp.results):
+                state.visited_docids.add(state.serp.results[click_index - 1].docid)
 
         output = ClickExperimentOutput(
             session_name=settings.name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,8 @@ def patched_services(monkeypatch, fake_llm, fake_search, fake_dataset):
 
 
 def make_settings(name="test_experiment", plan=None, loop_num_per_topic=1,
-                  max_actions=None, stages=None) -> ExperimentSettings:
+                  max_actions=None, stages=None,
+                  mark_visited_results=True) -> ExperimentSettings:
     return ExperimentSettings(
         name=name,
         task=TaskDescription(
@@ -86,4 +87,5 @@ def make_settings(name="test_experiment", plan=None, loop_num_per_topic=1,
         plan=plan,
         loop_num_per_topic=loop_num_per_topic,
         max_actions=max_actions,
+        mark_visited_results=mark_visited_results,
     )

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -62,6 +62,9 @@ class FakeLLMService:
     def __init__(self, next_actions: List[Action] | None = None):
         self.calls: list[tuple[str, int]] = []
         self.next_actions: list[Action] = list(next_actions or [])
+        # Instructions as the model saw them, for tests that assert on the
+        # rendered prompt text rather than on the emitted records.
+        self.prompts: list[tuple[str, str]] = []
 
     def _canned_response(self, instruction, response_model):
         if response_model is Query:
@@ -80,6 +83,7 @@ class FakeLLMService:
     def generate(self, model, memory, instruction, response_model):
         self.calls.append((response_model.__name__, len(memory._history)))
         response = self._canned_response(instruction, response_model)
+        self.prompts.append((type(instruction).__name__, instruction.generate()))
         memory.add_user_message(instruction.generate())
         memory.add_assistant_response(response.model_dump_json())
         return response, FAKE_TOTAL_TOKEN, FAKE_THINKING

--- a/tests/test_visited_marker.py
+++ b/tests/test_visited_marker.py
@@ -1,0 +1,71 @@
+"""Visited-result marking: the SERP equivalent of a browser's visited links.
+
+The fake LLM always clicks rank 1 (d1), so a plan with two search iterations
+gives each topic one unmarked SERP and one where d1 should carry the marker.
+"""
+from geniie_lab.dataclasses.serp import SearchResultItem
+from geniie_lab.experiments.session_experiment import ExperimentRunner
+
+from tests.conftest import make_settings
+
+TWO_ITERATIONS = ["query", "ranking", "click", "reformulate", "ranking", "click"]
+
+
+def click_prompts(fake_llm, topic_index):
+    """The rendered click prompts for one topic, in plan order."""
+    prompts = [text for kind, text in fake_llm.prompts if kind == "ClickInstruction"]
+    per_topic = len([s for s in TWO_ITERATIONS if s == "click"])
+    return prompts[topic_index * per_topic:(topic_index + 1) * per_topic]
+
+
+def test_unvisited_repr_is_unchanged_by_the_new_field():
+    # Also guards score staying absent, which the hand-written repr could leak.
+    item = SearchResultItem(ranking=1, docid="d1", title="Doc One",
+                            snippet="about topic one", score=2.0)
+    assert repr(item) == (
+        "SearchResultItem(ranking=1, docid='d1', title='Doc One', "
+        "snippet='about topic one')"
+    )
+
+
+def test_visited_repr_adds_only_the_marker():
+    item = SearchResultItem(ranking=1, docid="d1", title="Doc One",
+                            snippet="about topic one", score=2.0, visited=True)
+    assert repr(item) == (
+        "SearchResultItem(ranking=1, docid='d1', title='Doc One', "
+        "snippet='about topic one', visited=True)"
+    )
+
+
+def test_visited_is_serialised_even_when_hidden_from_the_searcher():
+    assert SearchResultItem(ranking=1, docid="d1", title="t",
+                            snippet="s").to_dict()["visited"] is False
+
+
+def test_clicked_document_is_marked_in_the_next_serp(patched_services):
+    settings = make_settings(plan=TWO_ITERATIONS, mark_visited_results=True)
+    ExperimentRunner(settings=settings).run()
+
+    first, second = click_prompts(patched_services.llm, topic_index=0)
+    assert "visited=True" not in first  # nothing opened yet
+    assert "docid='d1', title='Doc One', snippet='about topic one', visited=True" in second
+    assert "docid='d2'" in second and "visited" not in second.split("docid='d2'")[1]
+
+
+def test_marks_do_not_leak_across_topics(patched_services):
+    settings = make_settings(plan=TWO_ITERATIONS, mark_visited_results=True)
+    ExperimentRunner(settings=settings).run()
+
+    # t2 starts unmarked even though d1 was opened while working on t1.
+    first_of_t2, second_of_t2 = click_prompts(patched_services.llm, topic_index=1)
+    assert "visited=True" not in first_of_t2
+    assert "visited=True" in second_of_t2
+
+
+def test_flag_off_leaves_the_prompt_byte_identical(patched_services):
+    settings = make_settings(plan=TWO_ITERATIONS, mark_visited_results=False)
+    ExperimentRunner(settings=settings).run()
+
+    first, second = click_prompts(patched_services.llm, topic_index=0)
+    assert "visited" not in second
+    assert first == second  # same SERP, and nothing marks it

--- a/tests/test_visited_marker.py
+++ b/tests/test_visited_marker.py
@@ -4,7 +4,9 @@ The fake LLM always clicks rank 1 (d1), so a plan with two search iterations
 gives each topic one unmarked SERP and one where d1 should carry the marker.
 """
 from geniie_lab.dataclasses.serp import SearchResultItem
+from geniie_lab.experiments.agentic_experiment import ExperimentRunner as AgenticRunner
 from geniie_lab.experiments.session_experiment import ExperimentRunner
+from geniie_lab.response import Action
 
 from tests.conftest import make_settings
 
@@ -69,3 +71,18 @@ def test_flag_off_leaves_the_prompt_byte_identical(patched_services):
     first, second = click_prompts(patched_services.llm, topic_index=0)
     assert "visited" not in second
     assert first == second  # same SERP, and nothing marks it
+
+
+def test_agentic_marks_a_reused_serp_without_a_new_ranking(patched_services):
+    # CLICK_DOCUMENT runs no ranking stage, so the second click renders the
+    # SERP object built for the first one. The marks must still be there.
+    patched_services.llm.next_actions = [Action.CLICK_DOCUMENT, Action.END_TASK]
+    settings = make_settings(name="test_agentic", max_actions=10,
+                             mark_visited_results=True)
+    AgenticRunner(settings=settings).run()
+
+    prompts = [text for kind, text in patched_services.llm.prompts
+               if kind == "ClickInstruction"]
+    first, second = prompts[0], prompts[1]
+    assert "visited=True" not in first
+    assert "docid='d1', title='Doc One', snippet='about topic one', visited=True" in second


### PR DESCRIPTION
Closes #55.

Adds a `visited` field to `SearchResultItem` recording whether the searcher has already opened that document in the current session.

- `SearchResultItem.visited`, rendered by a hand-written `__repr__` only when true, so an unmarked SERP renders exactly as before. `to_json` always includes the field.
- `ExperimentState.visited_docids`, a per-topic set keyed by docid, so a mark survives reformulation, re-ranking and pagination. Both runners build fresh state per topic, so it resets between topics.
- The click stage records clicked docids, and applies the marks just before rendering the SERP. Marking at render time rather than when the SERP is built matters for the agentic runner, where `CLICK_DOCUMENT` runs no ranking stage and re-renders the SERP built for the previous click.
- `ExperimentSettings.mark_visited_results` gates the rendering. Defaults to `True`; set `False` to reproduce previous behaviour.

Applied to `session_experiment.py` and `agentic_experiment.py`. `repetition_experiment.py` keeps its own copy of the stages and is left unchanged.

Tests in `tests/test_visited_marker.py` cover both repr shapes, serialisation, marking across iterations, isolation between topics, an unchanged rendering when the setting is off, and the agentic reused-SERP case. 48 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)