### PR TITLE
Per-subtopic relevance judgement for diversity/intent experiments

### DIFF
--- a/geniie_lab/dataclasses/output.py
+++ b/geniie_lab/dataclasses/output.py
@@ -128,7 +128,11 @@ class SubtopicRelevanceJudgementExperimentOutput(DataClassJsonMixin):
     docid: str
     label: str                                   # derived: Relevant iff any grade >= threshold
     assessments: List[Dict]                      # [{subtopic, grade, evidence}, ...]
-    subtopic_qrel_labels: Dict[str, int]         # subtopic id -> official label (judged subtopics only)
+    # One entry per subtopic shown to the model: the official grade where the
+    # qrels record one, 0 otherwise. Diversity collections do not record
+    # nonrelevance per subtopic, so absent is nonrelevant (ndeval convention);
+    # listing only graded subtopics would hide every assessor "no" (issue #57).
+    subtopic_qrel_labels: Dict[str, int]
     qrel_label: Optional[int] = 0                # topic-level official label (max over subtopics)
     threshold: Optional[int] = 2
     repetition: Optional[str] = 1

--- a/geniie_lab/dataclasses/output.py
+++ b/geniie_lab/dataclasses/output.py
@@ -113,3 +113,28 @@ class NextActionOutput(DataClassJsonMixin):
     thinking: Optional[str] = None
     thinking_token: Optional[int] = None
     created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+@dataclass_json
+@dataclass
+class SubtopicRelevanceJudgementExperimentOutput(DataClassJsonMixin):
+    """Record of a per-subtopic relevance judgement (diversity/intent tasks):
+    one record per judged document, carrying the grade the model assigned to
+    every listed subtopic alongside the official per-subtopic qrel labels."""
+    session_name: str
+    model: str
+    task: str
+    dataset: str
+    topic_id: str
+    docid: str
+    label: str                                   # derived: Relevant iff any grade >= threshold
+    assessments: List[Dict]                      # [{subtopic, grade, evidence}, ...]
+    subtopic_qrel_labels: Dict[str, int]         # subtopic id -> official label (judged subtopics only)
+    qrel_label: Optional[int] = 0                # topic-level official label (max over subtopics)
+    threshold: Optional[int] = 2
+    repetition: Optional[str] = 1
+    reason: Optional[str] = None
+    stage: Optional[str] = "rel_judge"
+    total_token: Optional[int] = 0
+    thinking: Optional[str] = None
+    thinking_token: Optional[int] = None
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())

--- a/geniie_lab/dataclasses/setting.py
+++ b/geniie_lab/dataclasses/setting.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Literal, Optional, Union
 
 # Local application imports
 from geniie_lab.dataclasses.serp import Serp, FullText
-from geniie_lab.response import Clicks, Query, RelevanceJudgement, Action
+from geniie_lab.response import Clicks, Query, RelevanceJudgement, SubtopicRelevanceJudgement, Action
 from geniie_lab.dataclasses.description import (
     CorpusDescription,
     ModelDescription,
@@ -29,6 +29,13 @@ class StageConfig:
     # so per-stage thinking cost stays measurable. Generation is unaffected —
     # this only controls what lands in the session log.
     log_thinking: bool = False
+    # Optional structured-output schema override for the stage. Currently
+    # honoured by the relevance stage: set to SubtopicRelevanceJudgement for
+    # per-subtopic grading on diversity/intent topics (the document is judged
+    # against every subtopic in one call; the classic binary label is derived
+    # as Relevant iff any grade >= relevance_threshold).
+    response_model: Optional[type] = None
+    relevance_threshold: int = 2
 
 @dataclass
 class ExperimentSettings:
@@ -56,7 +63,7 @@ class ExperimentState:
     docids: Optional[List[str]] = None
     clicks: Optional[Clicks] = None
     fulltext: Optional[FullText] = None
-    relevance_judgement: Optional[RelevanceJudgement] = None
+    relevance_judgement: Optional[Union[RelevanceJudgement, SubtopicRelevanceJudgement]] = None
     error: Optional[str] = None
     action_num: Optional[int] = 1
     next_action: Optional[Action] = None

--- a/geniie_lab/dataclasses/topic.py
+++ b/geniie_lab/dataclasses/topic.py
@@ -117,7 +117,8 @@ class TrecDiversityTopic(SubtopicTopic):
             topic_type=getattr(raw, "type", None),
             subtopics=[
                 Subtopic(number=str(getattr(s, "number", i + 1)),
-                         text=" ".join(s.text.split()))
+                         text=" ".join(s.text.split()),
+                         intent_type=getattr(s, "type", None) or None)
                 for i, s in enumerate(raw.subtopics)
             ],
         )
@@ -143,6 +144,50 @@ class NtcirIntentTopic(SubtopicTopic):
                 for s in raw.subtopics
             ],
         )
+
+# Subtopic-presenting variants: same data as their parents, but __str__ (the
+# text injected into prompts) includes the subtopic components. Which class
+# an experiment uses is its presentation choice, exactly like the
+# TitleOnly/TitleDescription family above. Selection policies (e.g. showing
+# only the most probable intents) belong to the experiment, which can
+# subclass and filter; these classes present everything they carry.
+
+@dataclass
+class TrecDiversitySubtopicsTopic(TrecDiversityTopic):
+    """TREC diversity topic presenting all available information: title,
+    description, topic type, and the numbered subtopics with their types."""
+
+    def __str__(self):
+        parts = [f"- **Title**: {self.title}"]
+        if self.description:
+            parts.append(f"- **Description**: {self.description}")
+        if self.topic_type:
+            parts.append(f"- **Topic type**: {self.topic_type}")
+        if self.subtopics:
+            parts.append("- **Subtopics**:")
+            for s in self.subtopics:
+                tag = f" ({s.intent_type})" if s.intent_type else ""
+                parts.append(f"  {s.number}.{tag} {s.text}")
+        return "\n".join(parts)
+
+@dataclass
+class NtcirIntentSubtopicsTopic(NtcirIntentTopic):
+    """NTCIR INTENT topic presenting all available information: query and the
+    numbered intents with probabilities and (where present) nav/inf types."""
+
+    def __str__(self):
+        parts = [f"- **Title**: {self.title}"]
+        if self.subtopics:
+            parts.append("- **Subtopics**:")
+            for s in self.subtopics:
+                attrs = []
+                if s.probability is not None:
+                    attrs.append(f"p={s.probability:.3f}")
+                if s.intent_type:
+                    attrs.append(s.intent_type)
+                tag = f" ({', '.join(attrs)})" if attrs else ""
+                parts.append(f"  {s.number}.{tag} {s.text}")
+        return "\n".join(parts)
 
 T = TypeVar("T", bound=BaseTopic)
 

--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -238,11 +238,24 @@ class RelevanceJudgementStage:
                 # as Relevant iff any subtopic grade reaches the threshold.
                 threshold = self.config.relevance_threshold
                 relevant = any(a.grade >= threshold for a in state.relevance_judgement.assessments)
-                subtopic_qrel_labels = {}
+                # One entry per subtopic the model was shown. Diversity
+                # collections do not record nonrelevance per subtopic: TREC
+                # 2009 marks a document that satisfies nothing with a single
+                # `subtopic 0, relevance 0` row, and NTCIR INTENT lists only
+                # graded intents. Reporting just the rows that exist therefore
+                # hides every assessor "no", and a consumer comparing agent
+                # grades against this field measures precision as 1.0 by
+                # construction (issue #57). Absent means nonrelevant, the
+                # standard ndeval convention, so absent is recorded as 0.
+                graded = {}
                 for row in dataset.qrels_iter():
                     if row.query_id == state.topic.id and row.doc_id == click_docid:
                         subtopic = str(getattr(row, "subtopic_id", None) or getattr(row, "iteration", "0"))
-                        subtopic_qrel_labels[subtopic] = max(subtopic_qrel_labels.get(subtopic, row.relevance), row.relevance)
+                        graded[subtopic] = max(graded.get(subtopic, row.relevance), row.relevance)
+                subtopic_qrel_labels = {
+                    str(a.subtopic): graded.get(str(a.subtopic), 0)
+                    for a in state.relevance_judgement.assessments
+                }
                 output = SubtopicRelevanceJudgementExperimentOutput(
                     session_name = settings.name,
                     model = model.name,
@@ -253,7 +266,7 @@ class RelevanceJudgementStage:
                     label = "Relevance.RELEVANT" if relevant else "Relevance.NOT_RELEVANT",
                     assessments = [a.model_dump() for a in state.relevance_judgement.assessments],
                     subtopic_qrel_labels = subtopic_qrel_labels,
-                    qrel_label = max(subtopic_qrel_labels.values(), default=0),
+                    qrel_label = max(graded.values(), default=0),
                     threshold = threshold,
                     reason = getattr(state.relevance_judgement, "reason", None),
                     total_token = total_token,

--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -14,7 +14,9 @@ from geniie_lab.dataclasses.topic import (
     TitleNarrativeTopic,
     TitleOnlyTopic,
     TrecDiversityTopic,
+    TrecDiversitySubtopicsTopic,
     NtcirIntentTopic,
+    NtcirIntentSubtopicsTopic,
     TopicList,
     BaseTopic
 )
@@ -30,9 +32,10 @@ from geniie_lab.dataclasses.output import (
     QueryReformulationExperimentOutput,
     RankingExperimentOutput,
     RelevanceJudgementExperimentOutput,
+    SubtopicRelevanceJudgementExperimentOutput,
 )
 from geniie_lab.memory import ConversationHistory
-from geniie_lab.response import Clicks, Query, RelevanceJudgement
+from geniie_lab.response import Clicks, Query, RelevanceJudgement, SubtopicRelevanceJudgement
 from geniie_lab.services.llm.llm_service_factory import LLMServiceFactory
 from geniie_lab.services.llm.llm_service_protocol import LLMServiceProtocol
 from geniie_lab.services.measure_service import MeasureService, Qrels, Run
@@ -208,26 +211,55 @@ class RelevanceJudgementStage:
             instruction_text = self.config.instruction or self.DEFAULT_INSTRUCTION
             rj_instruction = RelevanceJudgementInstruction(instruction=instruction_text, fulltext=state.fulltext)
 
-            state.relevance_judgement, total_token, thinking = llm_service.generate(model, state.memory, rj_instruction, RelevanceJudgement)
+            response_model = self.config.response_model or RelevanceJudgement
+            state.relevance_judgement, total_token, thinking = llm_service.generate(model, state.memory, rj_instruction, response_model)
             thinking_token = llm_service.get_tokenizer(model.name)(thinking) if thinking else None
             if not self.config.log_thinking:
                 thinking = None
 
             qrel_label = qrels.get(state.topic.id, click_docid, default=0)
 
-            output = RelevanceJudgementExperimentOutput(
-                session_name = settings.name,
-                model = model.name,
-                task = settings.task.name,
-                dataset = settings.topicset.name,
-                topic_id = state.topic.id,
-                docid = click_docid,
-                label = f"{state.relevance_judgement.label}",
-                qrel_label=qrel_label,
-                total_token = total_token,
-                thinking = thinking,
-                thinking_token = thinking_token
-            )
+            if isinstance(state.relevance_judgement, SubtopicRelevanceJudgement):
+                # Per-subtopic judgement: the classic binary label is derived
+                # as Relevant iff any subtopic grade reaches the threshold.
+                threshold = self.config.relevance_threshold
+                relevant = any(a.grade >= threshold for a in state.relevance_judgement.assessments)
+                subtopic_qrel_labels = {}
+                for row in dataset.qrels_iter():
+                    if row.query_id == state.topic.id and row.doc_id == click_docid:
+                        subtopic = str(getattr(row, "subtopic_id", None) or getattr(row, "iteration", "0"))
+                        subtopic_qrel_labels[subtopic] = max(subtopic_qrel_labels.get(subtopic, row.relevance), row.relevance)
+                output = SubtopicRelevanceJudgementExperimentOutput(
+                    session_name = settings.name,
+                    model = model.name,
+                    task = settings.task.name,
+                    dataset = settings.topicset.name,
+                    topic_id = state.topic.id,
+                    docid = click_docid,
+                    label = "Relevance.RELEVANT" if relevant else "Relevance.NOT_RELEVANT",
+                    assessments = [a.model_dump() for a in state.relevance_judgement.assessments],
+                    subtopic_qrel_labels = subtopic_qrel_labels,
+                    qrel_label = max(subtopic_qrel_labels.values(), default=0),
+                    threshold = threshold,
+                    reason = getattr(state.relevance_judgement, "reason", None),
+                    total_token = total_token,
+                    thinking = thinking,
+                    thinking_token = thinking_token
+                )
+            else:
+                output = RelevanceJudgementExperimentOutput(
+                    session_name = settings.name,
+                    model = model.name,
+                    task = settings.task.name,
+                    dataset = settings.topicset.name,
+                    topic_id = state.topic.id,
+                    docid = click_docid,
+                    label = f"{state.relevance_judgement.label}",
+                    qrel_label=qrel_label,
+                    total_token = total_token,
+                    thinking = thinking,
+                    thinking_token = thinking_token
+                )
             print(output.to_json(ensure_ascii=False), flush=True)
 
         return state
@@ -296,7 +328,9 @@ class ExperimentRunner:
             TitleDescriptionNarrativeTopic: TopicList[TitleDescriptionNarrativeTopic],
             FullTopic: TopicList[FullTopic],  # Optional, same as above
             TrecDiversityTopic: TopicList[TrecDiversityTopic],
+            TrecDiversitySubtopicsTopic: TopicList[TrecDiversitySubtopicsTopic],
             NtcirIntentTopic: TopicList[NtcirIntentTopic],
+            NtcirIntentSubtopicsTopic: TopicList[NtcirIntentSubtopicsTopic],
         }
 
         self.llm_factory = LLMServiceFactory()

--- a/geniie_lab/response.py
+++ b/geniie_lab/response.py
@@ -98,3 +98,48 @@ class NextAction(BaseModel):
         title="reason",
         description="A brief explanation for choosing this action."
     )
+
+class SubtopicGrade(BaseModel):
+    """One subtopic's relevance grade for a single document."""
+    subtopic: int = Field(
+        ...,
+        title="subtopic",
+        description="The number of the subtopic as listed in the search topic."
+    )
+    grade: int = Field(
+        ...,
+        ge=0,
+        le=3,
+        title="grade",
+        description=(
+            "0: the document does not address this subtopic. "
+            "1: related to this subtopic but does not satisfy the need it expresses. "
+            "2: satisfies the need expressed by this subtopic. "
+            "3: dedicated to this subtopic and satisfies it completely."
+        )
+    )
+    evidence: str = Field(
+        "",
+        title="evidence",
+        description=(
+            "A short quotation from the document supporting a grade above 0. "
+            "Empty string when the grade is 0."
+        )
+    )
+
+class SubtopicRelevanceJudgement(BaseModel):
+    """A model for grading a document against every subtopic of the search
+    topic, one entry per listed subtopic."""
+    assessments: List[SubtopicGrade] = Field(
+        ...,
+        title="assessments",
+        description=(
+            "One entry per subtopic listed in the search topic, in the listed "
+            "order, each with its grade and evidence."
+        )
+    )
+    reason: str = Field(
+        ...,
+        title="reason",
+        description="A brief explanation supporting your judgments."
+    )

--- a/geniie_lab/response.py
+++ b/geniie_lab/response.py
@@ -122,8 +122,9 @@ class SubtopicGrade(BaseModel):
         "",
         title="evidence",
         description=(
-            "A short quotation from the document supporting a grade above 0. "
-            "Empty string when the grade is 0."
+            "A verbatim quotation copied from the document that supports this "
+            "grade: the quoted text only, with no commentary or explanation "
+            "(put those in the reason field). Empty string when the grade is 0."
         )
     )
 
@@ -135,11 +136,14 @@ class SubtopicRelevanceJudgement(BaseModel):
         title="assessments",
         description=(
             "One entry per subtopic listed in the search topic, in the listed "
-            "order, each with its grade and evidence."
+            "order, each with its grade and supporting quotation."
         )
     )
     reason: str = Field(
         ...,
         title="reason",
-        description="A brief explanation supporting your judgments."
+        description=(
+            "A brief explanation of your judgments across the subtopics: why "
+            "the document does or does not satisfy each of them."
+        )
     )

--- a/tests/test_subtopic_judgement.py
+++ b/tests/test_subtopic_judgement.py
@@ -1,0 +1,115 @@
+"""Tests for per-subtopic relevance judgement (subtopic-presenting topics,
+SubtopicRelevanceJudgement schema, and the derived binary label)."""
+
+import pytest
+from pydantic import ValidationError
+
+from geniie_lab.dataclasses.output import SubtopicRelevanceJudgementExperimentOutput
+from geniie_lab.dataclasses.setting import StageConfig
+from geniie_lab.dataclasses.topic import (
+    NtcirIntentSubtopicsTopic,
+    Subtopic,
+    TrecDiversitySubtopicsTopic,
+)
+from geniie_lab.response import SubtopicGrade, SubtopicRelevanceJudgement
+
+
+def make_trec_topic():
+    return TrecDiversitySubtopicsTopic(
+        id="20",
+        title="defender",
+        description="Find information about the Land Rover Defender.",
+        topic_type="ambiguous",
+        subtopics=[
+            Subtopic(number="1", text="Land Rover Defender SUV", intent_type="inf"),
+            Subtopic(number="2", text="Defender arcade game", intent_type="nav"),
+        ],
+    )
+
+
+class TestSubtopicPresentingTopics:
+    def test_trec_presents_all_information(self):
+        rendered = str(make_trec_topic())
+        assert "- **Title**: defender" in rendered
+        assert "Land Rover Defender." in rendered          # description
+        assert "ambiguous" in rendered                      # topic type
+        assert "1. (inf) Land Rover Defender SUV" in rendered
+        assert "2. (nav) Defender arcade game" in rendered
+
+    def test_ntcir_presents_probabilities_and_types(self):
+        topic = NtcirIntentSubtopicsTopic(
+            id="0101",
+            title="日露戦争",
+            subtopics=[
+                Subtopic(number="1", text="cause", probability=0.16, intent_type=None),
+                Subtopic(number="2", text="timeline", probability=0.14, intent_type="inf"),
+            ],
+        )
+        rendered = str(topic)
+        assert "1. (p=0.160) cause" in rendered
+        assert "2. (p=0.140, inf) timeline" in rendered
+
+    def test_parent_classes_stay_title_only(self):
+        # The presentation split: parents never show subtopics.
+        from geniie_lab.dataclasses.topic import TrecDiversityTopic
+        parent = TrecDiversityTopic(**vars(make_trec_topic()))
+        assert str(parent) == "- **Title**: defender"
+
+
+class TestSubtopicRelevanceJudgementSchema:
+    def test_grade_bounds_enforced(self):
+        with pytest.raises(ValidationError):
+            SubtopicGrade(subtopic=1, grade=4, evidence="x")
+        with pytest.raises(ValidationError):
+            SubtopicGrade(subtopic=1, grade=-1, evidence="x")
+
+    def test_evidence_defaults_empty(self):
+        assert SubtopicGrade(subtopic=1, grade=0).evidence == ""
+
+    def test_reason_required(self):
+        with pytest.raises(ValidationError):
+            SubtopicRelevanceJudgement(assessments=[])
+
+
+class TestDerivedLabel:
+    @staticmethod
+    def derive(grades, threshold=2):
+        judgement = SubtopicRelevanceJudgement(
+            assessments=[SubtopicGrade(subtopic=i + 1, grade=g, evidence="e" if g else "")
+                         for i, g in enumerate(grades)],
+            reason="r",
+        )
+        return any(a.grade >= threshold for a in judgement.assessments)
+
+    def test_all_zeros_is_not_relevant(self):
+        assert self.derive([0, 0, 0]) is False
+
+    def test_grade_one_is_not_relevant(self):
+        assert self.derive([1, 1, 0]) is False
+
+    def test_any_grade_two_is_relevant(self):
+        assert self.derive([0, 2, 0]) is True
+
+    def test_threshold_is_configurable(self):
+        assert self.derive([1, 1, 1], threshold=1) is True
+        assert self.derive([2, 2, 2], threshold=3) is False
+
+
+class TestOutputRecord:
+    def test_round_trips_to_json(self):
+        record = SubtopicRelevanceJudgementExperimentOutput(
+            session_name="s", model="m", task="t", dataset="d",
+            topic_id="20", docid="doc-1", label="Relevance.RELEVANT",
+            assessments=[{"subtopic": 1, "grade": 2, "evidence": "quote"}],
+            subtopic_qrel_labels={"1": 1, "2": 0},
+            qrel_label=1, threshold=2, reason="because",
+        )
+        blob = record.to_json()
+        assert '"assessments"' in blob and '"subtopic_qrel_labels"' in blob
+        assert record.stage == "rel_judge"
+
+    def test_stageconfig_carries_model_and_threshold(self):
+        config = StageConfig(response_model=SubtopicRelevanceJudgement,
+                             relevance_threshold=2)
+        assert config.response_model is SubtopicRelevanceJudgement
+        assert config.relevance_threshold == 2

--- a/tests/test_subtopic_judgement.py
+++ b/tests/test_subtopic_judgement.py
@@ -113,3 +113,24 @@ class TestOutputRecord:
                              relevance_threshold=2)
         assert config.response_model is SubtopicRelevanceJudgement
         assert config.relevance_threshold == 2
+
+
+class TestSubtopicQrelLabels:
+    """Every presented subtopic gets a label; absent means nonrelevant (#57)."""
+
+    @staticmethod
+    def build(graded, presented):
+        # mirrors the stage: graded rows from the qrels, one entry per subtopic
+        return {str(s): graded.get(str(s), 0) for s in presented}
+
+    def test_absent_subtopics_are_zero_not_missing(self):
+        labels = self.build({"2": 1}, presented=[1, 2, 3])
+        assert labels == {"1": 0, "2": 1, "3": 0}
+
+    def test_document_relevant_to_nothing_is_all_zero(self):
+        labels = self.build({"0": 0}, presented=[1, 2])
+        assert labels == {"1": 0, "2": 0}
+
+    def test_every_presented_subtopic_is_covered(self):
+        presented = [1, 2, 3, 4, 5]
+        assert set(self.build({"3": 2}, presented)) == {"1", "2", "3", "4", "5"}


### PR DESCRIPTION
Adds an optional per-subtopic relevance stage for diversity and intent collections, plus the topic classes that present subtopics to the model. Closes #57.

## What it adds

- **topic**: `TrecDiversitySubtopicsTopic` and `NtcirIntentSubtopicsTopic` present all available topic information (title, description, topic type, numbered subtopics with nav/inf types; NTCIR intents with probabilities). Their parents stay title-only, so which class an experiment names *is* the presentation choice — the same idiom as the TitleOnly/TitleDescription family.
- **response**: `SubtopicGrade` (anchored 0–3 with an evidence quotation) and `SubtopicRelevanceJudgement` (one entry per listed subtopic, plus `reason` like its sibling models).
- **stage**: `StageConfig.response_model` overrides the relevance stage's schema; the classic binary label is derived as Relevant iff any grade reaches `StageConfig.relevance_threshold` (default 2). Per-subtopic official labels are logged alongside.
- **output**: a dedicated `SubtopicRelevanceJudgementExperimentOutput` record, so the existing record type is untouched.

**Additive by default.** The relevance stage only takes the new path when `response_model` is set, so existing experiments behave exactly as before.

## Tests

15 tests covering presentation (parents unchanged), schema bounds, label derivation and threshold, the output record, and the #57 semantics. Full suite green (63) including the visited-results tests merged from dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)