### PR TITLE
refactor(subtopic): label subtopics with a rubric enum, drop derived label

### DIFF
--- a/geniie_lab/dataclasses/output.py
+++ b/geniie_lab/dataclasses/output.py
@@ -118,7 +118,7 @@ class NextActionOutput(DataClassJsonMixin):
 @dataclass
 class SubtopicRelevanceJudgementExperimentOutput(DataClassJsonMixin):
     """Record of a per-subtopic relevance judgement (diversity/intent tasks):
-    one record per judged document, carrying the grade the model assigned to
+    one record per judged document, carrying the label the model assigned to
     every listed subtopic alongside the official per-subtopic qrel labels."""
     session_name: str
     model: str
@@ -126,15 +126,11 @@ class SubtopicRelevanceJudgementExperimentOutput(DataClassJsonMixin):
     dataset: str
     topic_id: str
     docid: str
-    label: str                                   # derived: Relevant iff any grade >= threshold
-    assessments: List[Dict]                      # [{subtopic, grade, evidence}, ...]
-    # One entry per subtopic shown to the model: the official grade where the
-    # qrels record one, 0 otherwise. Diversity collections do not record
-    # nonrelevance per subtopic, so absent is nonrelevant (ndeval convention);
-    # listing only graded subtopics would hide every assessor "no" (issue #57).
-    subtopic_qrel_labels: Dict[str, int]
-    qrel_label: Optional[int] = 0                # topic-level official label (max over subtopics)
-    threshold: Optional[int] = 2
+    labels: List[Dict]                           # [{subtopic, label, evidence}, ...]
+    # One entry per subtopic shown to the model. Absent from the qrels means
+    # nonrelevant (ndeval convention): these collections record nonrelevance
+    # per document, not per subtopic (issue #57).
+    qrel_labels: Dict[str, int]
     repetition: Optional[str] = 1
     reason: Optional[str] = None
     stage: Optional[str] = "rel_judge"

--- a/geniie_lab/dataclasses/setting.py
+++ b/geniie_lab/dataclasses/setting.py
@@ -32,10 +32,8 @@ class StageConfig:
     # Optional structured-output schema override for the stage. Currently
     # honoured by the relevance stage: set to SubtopicRelevanceJudgement for
     # per-subtopic grading on diversity/intent topics (the document is judged
-    # against every subtopic in one call; the classic binary label is derived
-    # as Relevant iff any grade >= relevance_threshold).
+    # against every subtopic in one call).
     response_model: Optional[type] = None
-    relevance_threshold: int = 2
 
 @dataclass
 class ExperimentSettings:

--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -234,27 +234,19 @@ class RelevanceJudgementStage:
             qrel_label = qrels.get(state.topic.id, click_docid, default=0)
 
             if isinstance(state.relevance_judgement, SubtopicRelevanceJudgement):
-                # Per-subtopic judgement: the classic binary label is derived
-                # as Relevant iff any subtopic grade reaches the threshold.
-                threshold = self.config.relevance_threshold
-                relevant = any(a.grade >= threshold for a in state.relevance_judgement.assessments)
-                # One entry per subtopic the model was shown. Diversity
-                # collections do not record nonrelevance per subtopic: TREC
-                # 2009 marks a document that satisfies nothing with a single
-                # `subtopic 0, relevance 0` row, and NTCIR INTENT lists only
-                # graded intents. Reporting just the rows that exist therefore
-                # hides every assessor "no", and a consumer comparing agent
-                # grades against this field measures precision as 1.0 by
-                # construction (issue #57). Absent means nonrelevant, the
-                # standard ndeval convention, so absent is recorded as 0.
+                # One entry per subtopic the model was shown. Absent from the
+                # qrels means nonrelevant (ndeval convention): these
+                # collections record nonrelevance per document, not per
+                # subtopic, so listing only the graded rows would hide every
+                # assessor "no" (issue #57).
                 graded = {}
                 for row in dataset.qrels_iter():
                     if row.query_id == state.topic.id and row.doc_id == click_docid:
                         subtopic = str(getattr(row, "subtopic_id", None) or getattr(row, "iteration", "0"))
                         graded[subtopic] = max(graded.get(subtopic, row.relevance), row.relevance)
-                subtopic_qrel_labels = {
+                qrel_labels = {
                     str(a.subtopic): graded.get(str(a.subtopic), 0)
-                    for a in state.relevance_judgement.assessments
+                    for a in state.relevance_judgement.labels
                 }
                 output = SubtopicRelevanceJudgementExperimentOutput(
                     session_name = settings.name,
@@ -263,11 +255,8 @@ class RelevanceJudgementStage:
                     dataset = settings.topicset.name,
                     topic_id = state.topic.id,
                     docid = click_docid,
-                    label = "Relevance.RELEVANT" if relevant else "Relevance.NOT_RELEVANT",
-                    assessments = [a.model_dump() for a in state.relevance_judgement.assessments],
-                    subtopic_qrel_labels = subtopic_qrel_labels,
-                    qrel_label = max(graded.values(), default=0),
-                    threshold = threshold,
+                    labels = [a.model_dump(mode="json") for a in state.relevance_judgement.labels],
+                    qrel_labels = qrel_labels,
                     reason = getattr(state.relevance_judgement, "reason", None),
                     total_token = total_token,
                     thinking = thinking,

--- a/geniie_lab/response.py
+++ b/geniie_lab/response.py
@@ -9,6 +9,21 @@ class Relevance(str, Enum):
     RELEVANT = "Relevant"
     NOT_RELEVANT = "NotRelevant"
 
+class RubricRelevance(str, Enum):
+    """What happened to the information need a subtopic expresses."""
+    NOT_ADDRESSED = "NotAddressed"
+    ON_SUBTOPIC_ONLY = "OnSubtopicOnly"
+    NEED_SATISFIED = "NeedSatisfied"
+    COMPLETELY_SATISFIED = "CompletelySatisfied"
+
+# Rubric order, ascending. Use for "at least NEED_SATISFIED" comparisons.
+RUBRIC_ORDER = (
+    RubricRelevance.NOT_ADDRESSED,
+    RubricRelevance.ON_SUBTOPIC_ONLY,
+    RubricRelevance.NEED_SATISFIED,
+    RubricRelevance.COMPLETELY_SATISFIED,
+)
+
 class Action(Enum):
     """Enum describing possible user actions."""
     SUBMIT_NEW_QUERY = "SUBMIT_NEW_QUERY"
@@ -99,51 +114,42 @@ class NextAction(BaseModel):
         description="A brief explanation for choosing this action."
     )
 
-class SubtopicGrade(BaseModel):
-    """One subtopic's relevance grade for a single document."""
+class SubtopicRelevance(BaseModel):
+    """One subtopic's relevance label for a single document."""
     subtopic: int = Field(
         ...,
         title="subtopic",
         description="The number of the subtopic as listed in the search topic."
     )
-    grade: int = Field(
+    label: RubricRelevance = Field(
         ...,
-        ge=0,
-        le=3,
-        title="grade",
-        description=(
-            "0: the document does not address this subtopic. "
-            "1: related to this subtopic but does not satisfy the need it expresses. "
-            "2: satisfies the need expressed by this subtopic. "
-            "3: dedicated to this subtopic and satisfies it completely."
-        )
+        title="label",
+        description="The relevance label for this subtopic, as defined in the instruction."
     )
     evidence: str = Field(
         "",
         title="evidence",
         description=(
             "A verbatim quotation copied from the document that supports this "
-            "grade: the quoted text only, with no commentary or explanation "
-            "(put those in the reason field). Empty string when the grade is 0."
+            "label: the quoted text only, with no commentary or explanation "
+            "(put those in the reason field). Empty string when the label is "
+            "NotAddressed."
         )
     )
 
 class SubtopicRelevanceJudgement(BaseModel):
-    """A model for grading a document against every subtopic of the search
+    """A model for labelling a document against every subtopic of the search
     topic, one entry per listed subtopic."""
-    assessments: List[SubtopicGrade] = Field(
+    labels: List[SubtopicRelevance] = Field(
         ...,
-        title="assessments",
+        title="labels",
         description=(
             "One entry per subtopic listed in the search topic, in the listed "
-            "order, each with its grade and supporting quotation."
+            "order, each with its label and supporting quotation."
         )
     )
     reason: str = Field(
         ...,
         title="reason",
-        description=(
-            "A brief explanation of your judgments across the subtopics: why "
-            "the document does or does not satisfy each of them."
-        )
+        description="A brief explanation supporting your judgment."
     )

--- a/tests/test_subtopic_judgement.py
+++ b/tests/test_subtopic_judgement.py
@@ -1,5 +1,5 @@
 """Tests for per-subtopic relevance judgement (subtopic-presenting topics,
-SubtopicRelevanceJudgement schema, and the derived binary label)."""
+the SubtopicRelevanceJudgement schema, and the recorded output)."""
 
 import pytest
 from pydantic import ValidationError
@@ -11,7 +11,12 @@ from geniie_lab.dataclasses.topic import (
     Subtopic,
     TrecDiversitySubtopicsTopic,
 )
-from geniie_lab.response import SubtopicGrade, SubtopicRelevanceJudgement
+from geniie_lab.response import (
+    RUBRIC_ORDER,
+    RubricRelevance,
+    SubtopicRelevance,
+    SubtopicRelevanceJudgement,
+)
 
 
 def make_trec_topic():
@@ -56,63 +61,56 @@ class TestSubtopicPresentingTopics:
         assert str(parent) == "- **Title**: defender"
 
 
+class TestRubricRelevance:
+    def test_values_are_what_the_model_emits(self):
+        assert RubricRelevance.NOT_ADDRESSED == "NotAddressed"
+        assert RubricRelevance.COMPLETELY_SATISFIED == "CompletelySatisfied"
+
+    def test_rubric_order_supports_at_least_comparisons(self):
+        satisfied = RUBRIC_ORDER.index(RubricRelevance.NEED_SATISFIED)
+        assert RUBRIC_ORDER.index(RubricRelevance.ON_SUBTOPIC_ONLY) < satisfied
+        assert RUBRIC_ORDER.index(RubricRelevance.COMPLETELY_SATISFIED) > satisfied
+        assert len(RUBRIC_ORDER) == len(RubricRelevance)
+
+
 class TestSubtopicRelevanceJudgementSchema:
-    def test_grade_bounds_enforced(self):
+    def test_label_must_be_a_rubric_value(self):
         with pytest.raises(ValidationError):
-            SubtopicGrade(subtopic=1, grade=4, evidence="x")
+            SubtopicRelevance(subtopic=1, label="VeryRelevant", evidence="x")
         with pytest.raises(ValidationError):
-            SubtopicGrade(subtopic=1, grade=-1, evidence="x")
+            SubtopicRelevance(subtopic=1, label=2, evidence="x")
 
     def test_evidence_defaults_empty(self):
-        assert SubtopicGrade(subtopic=1, grade=0).evidence == ""
+        item = SubtopicRelevance(subtopic=1, label=RubricRelevance.NOT_ADDRESSED)
+        assert item.evidence == ""
 
     def test_reason_required(self):
         with pytest.raises(ValidationError):
-            SubtopicRelevanceJudgement(assessments=[])
-
-
-class TestDerivedLabel:
-    @staticmethod
-    def derive(grades, threshold=2):
-        judgement = SubtopicRelevanceJudgement(
-            assessments=[SubtopicGrade(subtopic=i + 1, grade=g, evidence="e" if g else "")
-                         for i, g in enumerate(grades)],
-            reason="r",
-        )
-        return any(a.grade >= threshold for a in judgement.assessments)
-
-    def test_all_zeros_is_not_relevant(self):
-        assert self.derive([0, 0, 0]) is False
-
-    def test_grade_one_is_not_relevant(self):
-        assert self.derive([1, 1, 0]) is False
-
-    def test_any_grade_two_is_relevant(self):
-        assert self.derive([0, 2, 0]) is True
-
-    def test_threshold_is_configurable(self):
-        assert self.derive([1, 1, 1], threshold=1) is True
-        assert self.derive([2, 2, 2], threshold=3) is False
+            SubtopicRelevanceJudgement(labels=[])
 
 
 class TestOutputRecord:
     def test_round_trips_to_json(self):
         record = SubtopicRelevanceJudgementExperimentOutput(
             session_name="s", model="m", task="t", dataset="d",
-            topic_id="20", docid="doc-1", label="Relevance.RELEVANT",
-            assessments=[{"subtopic": 1, "grade": 2, "evidence": "quote"}],
-            subtopic_qrel_labels={"1": 1, "2": 0},
-            qrel_label=1, threshold=2, reason="because",
+            topic_id="20", docid="doc-1",
+            labels=[{"subtopic": 1, "label": "NeedSatisfied", "evidence": "quote"}],
+            qrel_labels={"1": 1, "2": 0},
+            reason="because",
         )
         blob = record.to_json()
-        assert '"assessments"' in blob and '"subtopic_qrel_labels"' in blob
+        assert '"labels"' in blob and '"qrel_labels"' in blob
         assert record.stage == "rel_judge"
 
-    def test_stageconfig_carries_model_and_threshold(self):
-        config = StageConfig(response_model=SubtopicRelevanceJudgement,
-                             relevance_threshold=2)
+    def test_record_carries_no_derived_document_label(self):
+        # Per-subtopic labels are recorded; document relevance is analysis.
+        fields = SubtopicRelevanceJudgementExperimentOutput.__dataclass_fields__
+        assert "label" not in fields and "threshold" not in fields
+        assert "qrel_label" not in fields
+
+    def test_stageconfig_carries_response_model(self):
+        config = StageConfig(response_model=SubtopicRelevanceJudgement)
         assert config.response_model is SubtopicRelevanceJudgement
-        assert config.relevance_threshold == 2
 
 
 class TestSubtopicQrelLabels:


### PR DESCRIPTION
Closes #59. Follow-up to #57.

Replaces the numeric subtopic grade with a rubric enum, and stops recording a document-level label the model never produced.

## Schema

- New `RubricRelevance(str, Enum)`: `NotAddressed`, `OnSubtopicOnly`, `NeedSatisfied`, `CompletelySatisfied`, matching the house style of `Relevance`. Values name what happened to the information need rather than a degree of relevance, and remain legible in the conversation history that the reformulation stage re-reads. `RUBRIC_ORDER` sits beside it for "at least `NeedSatisfied`" comparisons.
- `SubtopicGrade` becomes `SubtopicRelevance`; `label: RubricRelevance` replaces the `ge=0, le=3` integer `grade`. The `evidence` description now refers to `NotAddressed` rather than grade 0; its verbatim-quotation requirement is unchanged.
- `SubtopicRelevanceJudgement.assessments` becomes `labels`, keeping the one-entry-per-subtopic-in-listed-order wording. `reason` reverts to the sibling models' wording.

## Record

`assessments`/`subtopic_qrel_labels` become `labels`/`qrel_labels`. `label`, `qrel_label` and `threshold` are removed, as is `StageConfig.relevance_threshold`. Document relevance is recoverable as "at least one subtopic reaches `NeedSatisfied`".

Nothing at runtime read the removed label: the stage computed it only for the record, and the reformulation stage reads the conversation history. The long comment block on the record is trimmed to the one line from #57 — absent from the qrels means nonrelevant, because these collections record nonrelevance per document rather than per subtopic.

The stage serialises with `model_dump(mode="json")`, so the enum lands in the JSONL as `"NeedSatisfied"` and the generated JSON schema exposes a plain string enum for structured output.

Deliberately not backward compatible with records written before this change; no migration path.

## Tests

`TestDerivedLabel` and the threshold case are gone. `TestRubricRelevance` covers the emitted values and the ordering helper, and the schema tests assert a non-rubric label is rejected. 62 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)