### PR TITLE
feat(llm): allow the schema in the prompt alongside grammar enforcement

### DIFF
--- a/docs/advanced/json_handling.md
+++ b/docs/advanced/json_handling.md
@@ -32,6 +32,33 @@ pipeline (issue #13), identical across providers:
    topic. The experiment as a whole is never lost to a single bad output,
    and the skip is explicit in the log.
 
+## How the schema reaches the model
+
+The response schema, including every field `title` and `description` written
+in `geniie-lab/response.py`, is sent as `response_format` with `strict: True`,
+so the provider's grammar prevents a non-conforming response rather than
+leaving it to the repair pipeline above.
+
+Two settings change that, and they are independent.
+
+- `schema_in_prompt` (default `False`) additionally appends the serialised
+  schema to the outgoing user message, putting the field descriptions in the
+  conversation, where models attend to them more than to the same text sent
+  out of band. The schema then goes over the wire twice. The suffix rides on
+  the outgoing copy only — session memory keeps the plain instruction, so
+  logged conversations stay identical across providers and settings.
+- `json_object_fallback` (default `False`) drops the `json_schema`
+  `response_format` for providers that mis-handle it, leaving no grammar. Such
+  a provider must also set `schema_in_prompt`, or nothing tells the model what
+  to produce. Amazon Bedrock is the only registry entry using it today, and it
+  sets both.
+
+The two settings also decide how the schema's tokens are reported. Chosen as
+an experimental condition, they are a real cost and count toward
+`total_token`. Forced by `json_object_fallback`, they are excluded, so a
+provider that cannot do grammar is not made to look costlier than one sending
+the same schema out of band.
+
 ## Reproducibility rationale
 
 Feedback retries are sometimes avoided on reproducibility grounds. We take

--- a/docs/advanced/json_handling.md
+++ b/docs/advanced/json_handling.md
@@ -48,10 +48,12 @@ Two settings change that, and they are independent.
   the outgoing copy only — session memory keeps the plain instruction, so
   logged conversations stay identical across providers and settings.
 - `json_object_fallback` (default `False`) drops the `json_schema`
-  `response_format` for providers that mis-handle it, leaving no grammar. Such
-  a provider must also set `schema_in_prompt`, or nothing tells the model what
-  to produce. Amazon Bedrock is the only registry entry using it today, and it
-  sets both.
+  `response_format` for deployments that mis-handle it, leaving no grammar.
+  Such an entry must also set `schema_in_prompt`, or nothing tells the model
+  what to produce. Amazon Bedrock is the only registry entry using it today,
+  and it sets both. Note the observation was made with one model there
+  (gpt-oss-120b), while the setting is per provider, so every model on that
+  entry loses grammar enforcement whether or not it needs to.
 
 The two settings also decide how the schema's tokens are reported. Chosen as
 an experimental condition, they are a real cost and count toward

--- a/geniie_lab/services/llm/llm_service_factory.py
+++ b/geniie_lab/services/llm/llm_service_factory.py
@@ -48,9 +48,11 @@ _REGISTRY: Dict[str, Callable[[], LLMServiceProtocol]] = {
         api_key=os.getenv("BEDROCK_API_KEY"),
         tiktoken_by_model=False,  # Bedrock model IDs are unknown to tiktoken
         # Bedrock's json_schema grammar for gpt-oss loops on whitespace
-        # (strict) or leaks stray prefix tokens (non-strict); see
-        # OpenAICompatibleLLMService.schema_via_prompt.
-        schema_via_prompt=True,
+        # (strict) or leaks stray prefix tokens (non-strict), so it falls back
+        # to json_object. That leaves no grammar, so the prompt must carry the
+        # schema: the two settings go together here.
+        json_object_fallback=True,
+        schema_in_prompt=True,
     ),
     "gemini": GeminiLLMService,
 }

--- a/geniie_lab/services/llm/llm_service_factory.py
+++ b/geniie_lab/services/llm/llm_service_factory.py
@@ -47,12 +47,7 @@ _REGISTRY: Dict[str, Callable[[], LLMServiceProtocol]] = {
                  f"{os.getenv('BEDROCK_REGION', 'us-west-2')}.api.aws/v1",
         api_key=os.getenv("BEDROCK_API_KEY"),
         tiktoken_by_model=False,  # Bedrock model IDs are unknown to tiktoken
-        # Observed with gpt-oss-120b here: the json_schema grammar loops on
-        # whitespace (strict) or leaks stray prefix tokens (non-strict). It
-        # may be that combination rather than Bedrock as a whole, but the
-        # setting is per provider, so every model on this entry gets it.
-        # The fallback leaves no grammar, so the prompt must carry the schema:
-        # the two settings go together here.
+        # json_schema is broken here for gpt-oss-120b; both settings go together.
         json_object_fallback=True,
         schema_in_prompt=True,
     ),

--- a/geniie_lab/services/llm/llm_service_factory.py
+++ b/geniie_lab/services/llm/llm_service_factory.py
@@ -47,10 +47,12 @@ _REGISTRY: Dict[str, Callable[[], LLMServiceProtocol]] = {
                  f"{os.getenv('BEDROCK_REGION', 'us-west-2')}.api.aws/v1",
         api_key=os.getenv("BEDROCK_API_KEY"),
         tiktoken_by_model=False,  # Bedrock model IDs are unknown to tiktoken
-        # Bedrock's json_schema grammar for gpt-oss loops on whitespace
-        # (strict) or leaks stray prefix tokens (non-strict), so it falls back
-        # to json_object. That leaves no grammar, so the prompt must carry the
-        # schema: the two settings go together here.
+        # Observed with gpt-oss-120b here: the json_schema grammar loops on
+        # whitespace (strict) or leaks stray prefix tokens (non-strict). It
+        # may be that combination rather than Bedrock as a whole, but the
+        # setting is per provider, so every model on this entry gets it.
+        # The fallback leaves no grammar, so the prompt must carry the schema:
+        # the two settings go together here.
         json_object_fallback=True,
         schema_in_prompt=True,
     ),

--- a/geniie_lab/services/llm/openai_compatible.py
+++ b/geniie_lab/services/llm/openai_compatible.py
@@ -52,11 +52,13 @@ class OpenAICompatibleLLMService:
         # default: it changes every prompt, and duplicates the schema on the
         # wire at the cost of the tokens.
         self._schema_in_prompt = schema_in_prompt
-        # For providers that mis-handle json_schema response_format (Amazon
-        # Bedrock with open-weight models: strict grammars loop on whitespace,
-        # non-strict ones leak stray tokens before the JSON). Drops grammar
-        # enforcement, leaving the repair-and-retry path to catch bad output,
-        # so it needs schema_in_prompt to tell the model what to produce.
+        # For deployments that mis-handle json_schema response_format
+        # (observed with gpt-oss-120b on Bedrock: strict grammars loop on
+        # whitespace, non-strict ones leak stray tokens before the JSON).
+        # Drops grammar enforcement, leaving the repair-and-retry path to
+        # catch bad output, so it needs schema_in_prompt to tell the model
+        # what to produce. Set per provider, so it applies to every model on
+        # that entry even if only one combination is affected.
         self._json_object_fallback = json_object_fallback
 
     def generate(

--- a/geniie_lab/services/llm/openai_compatible.py
+++ b/geniie_lab/services/llm/openai_compatible.py
@@ -42,16 +42,22 @@ class OpenAICompatibleLLMService:
         api_key: str | None = None,
         client: OpenAI | None = None,
         tiktoken_by_model: bool = True,
-        schema_via_prompt: bool = False,
+        schema_in_prompt: bool = False,
+        json_object_fallback: bool = False,
     ):
         self.client = client or OpenAI(base_url=base_url, api_key=api_key)
         self._tiktoken_by_model = tiktoken_by_model
-        # Some providers (e.g. Amazon Bedrock) mis-handle json_schema
-        # response_format for open-weight models: strict grammars loop on
-        # whitespace and non-strict ones leak stray tokens before the JSON.
-        # When set, send the schema in the prompt with json_object mode and
-        # validate the response ourselves instead.
-        self._schema_via_prompt = schema_via_prompt
+        # Field titles and descriptions reach the model either way, but out of
+        # band in response_format the model attends to them less. Off by
+        # default: it changes every prompt, and duplicates the schema on the
+        # wire at the cost of the tokens.
+        self._schema_in_prompt = schema_in_prompt
+        # For providers that mis-handle json_schema response_format (Amazon
+        # Bedrock with open-weight models: strict grammars loop on whitespace,
+        # non-strict ones leak stray tokens before the JSON). Drops grammar
+        # enforcement, leaving the repair-and-retry path to catch bad output,
+        # so it needs schema_in_prompt to tell the model what to produce.
+        self._json_object_fallback = json_object_fallback
 
     def generate(
         self,
@@ -109,16 +115,18 @@ class OpenAICompatibleLLMService:
     ) -> Tuple[T, int, str | None]:
         tokenizer = self.get_tokenizer(model)
 
-        # Store only the plain instruction in session memory: with
-        # schema_via_prompt the schema rides along on the outgoing copy only,
-        # so conversations stay identical across providers.
+        # Store only the plain instruction in session memory: the schema rides
+        # along on the outgoing copy only, so conversations stay identical
+        # across providers.
         memory.add_user_message(instruction.generate())
         # Pass roles through unchanged: the system prompt and previous
         # assistant turns must not be re-sent as user messages.
         messages: list[dict[str, str]] = memory.get_messages(tokenizer=tokenizer, max_tokens=token_length)
 
         schema_tokens = 0
-        if self._schema_via_prompt:
+        if self._schema_in_prompt:
+            # Appended to the outgoing copy only, so session memory stays
+            # identical across providers and conditions.
             schema_suffix = (
                 "\n\nRespond with ONLY a JSON object that conforms to this JSON schema:\n"
                 + json.dumps(response_model.model_json_schema())
@@ -126,11 +134,15 @@ class OpenAICompatibleLLMService:
             messages = messages[:-1] + [
                 {**messages[-1], "content": messages[-1]["content"] + schema_suffix}
             ]
-            # The schema suffix exists only to work around the provider's
-            # broken response_format; exclude it from the reported count so
-            # sessions stay token-comparable with providers that take the
-            # schema out-of-band. Approximate (trimming tokenizer).
-            schema_tokens = tokenizer(schema_suffix)
+            if self._json_object_fallback:
+                # Here the suffix is forced by the provider's broken
+                # response_format, so exclude it: the session stays
+                # token-comparable with providers that send the schema out of
+                # band. Approximate (trimming tokenizer). Requested as an
+                # experimental condition instead, it is a real cost and counts.
+                schema_tokens = tokenizer(schema_suffix)
+
+        if self._json_object_fallback:
             response_format = {"type": "json_object"}
         else:
             # strict matches what the SDK's parse() helper sent before the

--- a/geniie_lab/services/llm/openai_compatible.py
+++ b/geniie_lab/services/llm/openai_compatible.py
@@ -47,18 +47,9 @@ class OpenAICompatibleLLMService:
     ):
         self.client = client or OpenAI(base_url=base_url, api_key=api_key)
         self._tiktoken_by_model = tiktoken_by_model
-        # Field titles and descriptions reach the model either way, but out of
-        # band in response_format the model attends to them less. Off by
-        # default: it changes every prompt, and duplicates the schema on the
-        # wire at the cost of the tokens.
+        # Off by default: it changes every prompt and duplicates the schema.
         self._schema_in_prompt = schema_in_prompt
-        # For deployments that mis-handle json_schema response_format
-        # (observed with gpt-oss-120b on Bedrock: strict grammars loop on
-        # whitespace, non-strict ones leak stray tokens before the JSON).
-        # Drops grammar enforcement, leaving the repair-and-retry path to
-        # catch bad output, so it needs schema_in_prompt to tell the model
-        # what to produce. Set per provider, so it applies to every model on
-        # that entry even if only one combination is affected.
+        # Drops grammar enforcement, so it needs schema_in_prompt with it.
         self._json_object_fallback = json_object_fallback
 
     def generate(
@@ -117,9 +108,7 @@ class OpenAICompatibleLLMService:
     ) -> Tuple[T, int, str | None]:
         tokenizer = self.get_tokenizer(model)
 
-        # Store only the plain instruction in session memory: the schema rides
-        # along on the outgoing copy only, so conversations stay identical
-        # across providers.
+        # The schema rides on the outgoing copy only, never session memory.
         memory.add_user_message(instruction.generate())
         # Pass roles through unchanged: the system prompt and previous
         # assistant turns must not be re-sent as user messages.
@@ -127,8 +116,6 @@ class OpenAICompatibleLLMService:
 
         schema_tokens = 0
         if self._schema_in_prompt:
-            # Appended to the outgoing copy only, so session memory stays
-            # identical across providers and conditions.
             schema_suffix = (
                 "\n\nRespond with ONLY a JSON object that conforms to this JSON schema:\n"
                 + json.dumps(response_model.model_json_schema())
@@ -137,11 +124,7 @@ class OpenAICompatibleLLMService:
                 {**messages[-1], "content": messages[-1]["content"] + schema_suffix}
             ]
             if self._json_object_fallback:
-                # Here the suffix is forced by the provider's broken
-                # response_format, so exclude it: the session stays
-                # token-comparable with providers that send the schema out of
-                # band. Approximate (trimming tokenizer). Requested as an
-                # experimental condition instead, it is a real cost and counts.
+                # Forced by the provider, so excluded to stay comparable.
                 schema_tokens = tokenizer(schema_suffix)
 
         if self._json_object_fallback:

--- a/tests/test_llm_services.py
+++ b/tests/test_llm_services.py
@@ -107,15 +107,69 @@ def test_memory_never_contains_the_thinking_trace():
     assert '"reason": "r"' in stored
 
 
-def test_schema_via_prompt_appends_schema_to_outgoing_copy_only():
+def test_schema_stays_out_of_the_prompt_by_default():
     stub = StubClient(VALID_QUERY_JSON)
-    (response, _, _), memory = _service_call(stub, schema_via_prompt=True)
+    _service_call(stub)
+
+    assert "JSON schema" not in stub.calls[0]["messages"][-1]["content"]
+    assert stub.calls[0]["response_format"]["type"] == "json_schema"
+
+
+def test_schema_rides_on_the_outgoing_copy_only():
+    stub = StubClient(VALID_QUERY_JSON)
+    (response, _, _), memory = _service_call(stub, schema_in_prompt=True)
 
     assert response.query == "q"
-    assert stub.calls[0]["response_format"] == {"type": "json_object"}
     # Schema rides on the outgoing message; session memory keeps the plain one.
     assert "JSON schema" in stub.calls[0]["messages"][-1]["content"]
     assert "JSON schema" not in memory.get_all_messages()[-2]["content"]
+
+
+def test_schema_in_prompt_keeps_grammar_enforcement():
+    # The two settings are independent: the schema in the prompt does not cost
+    # the strict json_schema response_format.
+    stub = StubClient(VALID_QUERY_JSON)
+    _service_call(stub, schema_in_prompt=True)
+
+    assert "JSON schema" in stub.calls[0]["messages"][-1]["content"]
+    assert stub.calls[0]["response_format"]["type"] == "json_schema"
+    assert stub.calls[0]["response_format"]["json_schema"]["strict"] is True
+
+
+def test_json_object_fallback_drops_the_schema_response_format():
+    stub = StubClient(VALID_QUERY_JSON)
+    _service_call(stub, json_object_fallback=True)
+
+    assert stub.calls[0]["response_format"] == {"type": "json_object"}
+
+
+def test_bedrock_pairs_the_fallback_with_the_prompt_schema(monkeypatch):
+    # The fallback has no grammar, so that registry entry must also ask for
+    # the schema in the prompt or nothing tells the model what to produce.
+    from geniie_lab.services.llm.llm_service_factory import _REGISTRY
+
+    monkeypatch.setenv("BEDROCK_API_KEY", "test-key")
+    service = _REGISTRY["bedrock"]()
+    assert service._json_object_fallback is True
+    assert service._schema_in_prompt is True
+
+
+def test_schema_tokens_count_when_the_schema_is_a_choice():
+    stub = StubClient(VALID_QUERY_JSON)
+    (_, total_token, _), _ = _service_call(stub, schema_in_prompt=True)
+
+    assert total_token == 99  # the usage the provider reported, undiscounted
+
+
+def test_schema_tokens_are_excluded_when_the_provider_forces_them():
+    # A provider that cannot do grammar must send the schema in the prompt, so
+    # charging it for those tokens would make it look costlier than providers
+    # that send the same schema out of band.
+    stub = StubClient(VALID_QUERY_JSON)
+    (_, total_token, _), _ = _service_call(
+        stub, schema_in_prompt=True, json_object_fallback=True)
+
+    assert total_token < 99
 
 
 def test_repaired_output_needs_no_second_call():


### PR DESCRIPTION
Closes #63.

Splits `schema_via_prompt` into the two independent settings it conflated, so the response schema can appear in the prompt without giving up the strict `json_schema` response format.

## The settings

- `schema_in_prompt` (default `False`) appends the serialised schema to the outgoing user message. The suffix rides on the outgoing copy only, so session memory keeps the plain instruction and logged conversations stay identical across providers and settings.
- `json_object_fallback` (default `False`) drops the `json_schema` response format for deployments that mis-handle it.

Both default off, so no experiment changes behaviour unless it opts in. The Bedrock registry entry sets both: its fallback leaves no grammar, so it depends on the prompt carrying the schema. A test instantiates that entry and asserts the pairing, since splitting the two would silently leave nothing telling the model what to produce.

The old flag could not express prompt-schema *and* grammar enforcement together. That was a local `if`/`else`, not an API constraint — `response_format` and message content are independent, and a request may carry the schema in both places.

## Token accounting

Unchanged for Bedrock. Schema tokens stay excluded from `total_token` when `json_object_fallback` forces the suffix, so a deployment that cannot use grammar is not made to look costlier than one sending the same schema out of band. Requested as an experimental condition, with grammar still on, they count — the cost is chosen there.

## Known limits, not addressed here

- The rule keys on the provider entry, so it cannot tell "forced by the deployment" from "requested by the experiment" when both hold. Recording the raw total plus a separate schema-token field would remove the need for a rule at all, but it changes the `generate()` return type and all 13 stage call sites; it belongs with the Phase 2 stage unification.
- `json_object_fallback` is per provider, while the defect was observed with one model on it, so every model on that entry loses grammar enforcement regardless.

## Tests

Schema absent from the prompt by default; present when asked, with `strict: True` retained; outgoing-copy-only; the fallback dropping the response format; the Bedrock entry pairing both settings; and the two accounting cases. 73 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)