### PR TITLE
feat(relevance): make the document-level label scale selectable

### DIFF
--- a/docs/advanced/subtopic_judgement.md
+++ b/docs/advanced/subtopic_judgement.md
@@ -53,7 +53,9 @@ from geniie_lab.response import RubricRelevance, SubtopicRelevanceJudgement
     ),
 ```
 
-The scale must be given explicitly: a bare `SubtopicRelevanceJudgement` raises `specify a label scale, e.g. SubtopicRelevanceJudgement[RubricRelevance]`. Omit `response_model` altogether and the stage uses its own `RelevanceJudgement` schema, a single `Relevant`/`NotRelevant` label for the whole document.
+The scale must be given explicitly: a bare `SubtopicRelevanceJudgement` raises `specify a label scale, e.g. SubtopicRelevanceJudgement[RubricRelevance]`. Omit `response_model` altogether and the stage uses `RelevanceJudgement[Relevance]`, a single `Relevant`/`NotRelevant` label for the whole document.
+
+The same scales work without subtopics. `RelevanceJudgement[GradedRelevance]` gives one graded label per document, in the session, agentic and repetition experiments alike, and needs no subtopic-presenting topic class.
 
 The anchor wording belongs in the instruction, as above: the enum values alone name the levels but do not define them.
 

--- a/docs/experiments/common_settings.md
+++ b/docs/experiments/common_settings.md
@@ -154,7 +154,7 @@ Each stage has a name such as `query`, `ranking`, or `click`, and you can config
 
 - `instruction`: Instruction given to GII for each of the stages.
 - `log_thinking`: Reasoning models only — opt-in logging of the stage's reasoning-trace *text* into the session log's `thinking` field; `thinking_token` (estimated token count) is always recorded regardless (Default: `False`)
-- `response_model`: Structured-output schema override for the stage. Currently honoured by the `relevance` stage, where it switches GII from a single label per document to one label per subtopic. See [Per-subtopic relevance judgement](../advanced/subtopic_judgement.md) (Default: `None`, meaning the stage's own schema)
+- `response_model`: Structured-output schema override for the stage. Currently honoured by the `relevance` stage, in all three experiments, where it chooses the label scale — `RelevanceJudgement[GradedRelevance]` for one graded label per document, or `SubtopicRelevanceJudgement[...]` for one label per subtopic. The instruction must define whichever labels the scale offers. See [Per-subtopic relevance judgement](../advanced/subtopic_judgement.md) (Default: `None`, meaning `RelevanceJudgement[Relevance]`, the binary `Relevant`/`NotRelevant` judgement)
 
 ```python
     stages={

--- a/geniie_lab/experiments/agentic_experiment.py
+++ b/geniie_lab/experiments/agentic_experiment.py
@@ -32,7 +32,7 @@ from geniie_lab.dataclasses.output import (
     NextActionOutput,
 )
 from geniie_lab.memory import ConversationHistory
-from geniie_lab.response import Action, Clicks, NextAction, Query, RelevanceJudgement
+from geniie_lab.response import Action, Clicks, NextAction, Query, Relevance, RelevanceJudgement
 from geniie_lab.services.llm.llm_service_factory import LLMServiceFactory
 from geniie_lab.services.llm.llm_service_protocol import LLMServiceProtocol
 from geniie_lab.services.measure_service import MeasureService, Qrels, Run
@@ -215,7 +215,8 @@ class RelevanceJudgementStage:
             instruction_text = self.config.instruction or self.DEFAULT_INSTRUCTION
             rj_instruction = RelevanceJudgementInstruction(instruction=instruction_text, fulltext=state.fulltext)
 
-            state.relevance_judgement, total_token, thinking = llm_service.generate(model, state.memory, rj_instruction, RelevanceJudgement)
+            response_model = self.config.response_model or RelevanceJudgement[Relevance]
+            state.relevance_judgement, total_token, thinking = llm_service.generate(model, state.memory, rj_instruction, response_model)
             thinking_token = llm_service.get_tokenizer(model.name)(thinking) if thinking else None
             if not self.config.log_thinking:
                 thinking = None

--- a/geniie_lab/experiments/repetition_experiment.py
+++ b/geniie_lab/experiments/repetition_experiment.py
@@ -30,7 +30,7 @@ from geniie_lab.dataclasses.output import (
     RelevanceJudgementExperimentOutput,
 )
 from geniie_lab.memory import ConversationHistory
-from geniie_lab.response import Clicks, Query, RelevanceJudgement
+from geniie_lab.response import Clicks, Query, Relevance, RelevanceJudgement
 from geniie_lab.services.llm.llm_service_factory import LLMServiceFactory
 from geniie_lab.services.llm.llm_service_protocol import LLMServiceProtocol
 from geniie_lab.services.measure_service import MeasureService, Qrels, Run
@@ -202,7 +202,8 @@ class RelevanceJudgementStage:
             instruction_text = self.config.instruction or self.DEFAULT_INSTRUCTION
             rj_instruction = RelevanceJudgementInstruction(instruction=instruction_text, fulltext=state.fulltext)
 
-            state.relevance_judgement, total_token, thinking = llm_service.generate(model, state.memory, rj_instruction, RelevanceJudgement)
+            response_model = self.config.response_model or RelevanceJudgement[Relevance]
+            state.relevance_judgement, total_token, thinking = llm_service.generate(model, state.memory, rj_instruction, response_model)
             thinking_token = llm_service.get_tokenizer(model.name)(thinking) if thinking else None
             if not self.config.log_thinking:
                 thinking = None

--- a/geniie_lab/experiments/session_experiment.py
+++ b/geniie_lab/experiments/session_experiment.py
@@ -35,7 +35,7 @@ from geniie_lab.dataclasses.output import (
     SubtopicRelevanceJudgementExperimentOutput,
 )
 from geniie_lab.memory import ConversationHistory
-from geniie_lab.response import Clicks, Query, RelevanceJudgement, SubtopicRelevanceJudgement
+from geniie_lab.response import Clicks, Query, Relevance, RelevanceJudgement, SubtopicRelevanceJudgement
 from geniie_lab.services.llm.llm_service_factory import LLMServiceFactory
 from geniie_lab.services.llm.llm_service_protocol import LLMServiceProtocol
 from geniie_lab.services.measure_service import MeasureService, Qrels, Run
@@ -225,7 +225,7 @@ class RelevanceJudgementStage:
             instruction_text = self.config.instruction or self.DEFAULT_INSTRUCTION
             rj_instruction = RelevanceJudgementInstruction(instruction=instruction_text, fulltext=state.fulltext)
 
-            response_model = self.config.response_model or RelevanceJudgement
+            response_model = self.config.response_model or RelevanceJudgement[Relevance]
             state.relevance_judgement, total_token, thinking = llm_service.generate(model, state.memory, rj_instruction, response_model)
             thinking_token = llm_service.get_tokenizer(model.name)(thinking) if thinking else None
             if not self.config.log_thinking:

--- a/geniie_lab/response.py
+++ b/geniie_lab/response.py
@@ -42,6 +42,18 @@ class Action(Enum):
     END_TASK = "END_TASK"
 
 # Models
+class RequiresLabelScale(BaseModel, Generic[Label]):
+    """Base for models that must be parametrised with a label scale."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _require_label_scale(cls, data):
+        if cls.__pydantic_generic_metadata__["parameters"]:
+            raise ValueError(
+                f"specify a label scale, e.g. {cls.__name__}[RubricRelevance]"
+            )
+        return data
+
 class Query(BaseModel):
     """A model for submitting a query to a search tool."""
     query: str = Field(
@@ -95,9 +107,13 @@ class Clicks(BaseModel):
         description="A brief explanation for selecting these documents."
     )
 
-class RelevanceJudgement(BaseModel):
-    """A model for labeling a document's relevance."""
-    label: Relevance = Field(
+class RelevanceJudgement(RequiresLabelScale[Label]):
+    """A model for labeling a document's relevance.
+
+    Parametrised by the label scale: RelevanceJudgement[Relevance] for the
+    binary default, or [GradedRelevance] / [RubricRelevance].
+    """
+    label: Label = Field(
         ...,
         title="label",
         description=(
@@ -123,18 +139,6 @@ class NextAction(BaseModel):
         title="reason",
         description="A brief explanation for choosing this action."
     )
-
-class RequiresLabelScale(BaseModel, Generic[Label]):
-    """Base for models that must be parametrised with a label scale."""
-
-    @model_validator(mode="before")
-    @classmethod
-    def _require_label_scale(cls, data):
-        if cls.__pydantic_generic_metadata__["parameters"]:
-            raise ValueError(
-                f"specify a label scale, e.g. {cls.__name__}[RubricRelevance]"
-            )
-        return data
 
 class SubtopicRelevance(RequiresLabelScale[Label]):
     """One subtopic's relevance label for a single document.

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -13,6 +13,7 @@ from geniie_lab.response import (
     Action,
     Clicks,
     NextAction,
+    OrderedLabels,
     Query,
     Relevance,
     RelevanceJudgement,
@@ -66,15 +67,29 @@ class FakeLLMService:
         # rendered prompt text rather than on the emitted records.
         self.prompts: list[tuple[str, str]] = []
 
+    @staticmethod
+    def _origin_and_scale(response_model):
+        """A parametrised generic is not its own origin class, so dispatching
+        on identity needs the origin; the scale decides a valid label."""
+        meta = getattr(response_model, "__pydantic_generic_metadata__", {})
+        origin = meta.get("origin") or response_model
+        args = meta.get("args") or ()
+        return origin, (args[0] if args else None)
+
     def _canned_response(self, instruction, response_model):
+        origin, scale = self._origin_and_scale(response_model)
+        if origin is RelevanceJudgement:
+            # The most relevant label the scale offers, so a test can tell one
+            # scale from another: ordered scales end there, binary has no order.
+            label = (list(scale)[-1] if issubclass(scale, OrderedLabels)
+                     else Relevance.RELEVANT)
+            return response_model(label=label, reason="on topic")
         if response_model is Query:
             if isinstance(instruction, QueryReFormulationInstruction):
                 return Query(query="reformulated query", start=0, size=10, reason="try again")
             return Query(query="first query", start=0, size=10, reason="initial query")
         if response_model is Clicks:
             return Clicks(ranking_list=[1], reason="top result looks relevant")
-        if response_model is RelevanceJudgement:
-            return RelevanceJudgement(label=Relevance.RELEVANT, reason="on topic")
         if response_model is NextAction:
             action = self.next_actions.pop(0) if self.next_actions else Action.END_TASK
             return NextAction(action=action, reason="fake decision")

--- a/tests/test_document_label_scales.py
+++ b/tests/test_document_label_scales.py
@@ -1,0 +1,58 @@
+"""The document-level relevance label scale is selectable per experiment,
+in all three runners, and defaults to the binary Relevance scale."""
+from geniie_lab.dataclasses.setting import StageConfig
+from geniie_lab.experiments.agentic_experiment import ExperimentRunner as AgenticRunner
+from geniie_lab.experiments.repetition_experiment import ExperimentRunner as RepetitionRunner
+from geniie_lab.experiments.session_experiment import ExperimentRunner as SessionRunner
+from geniie_lab.response import GradedRelevance, RelevanceJudgement
+
+from tests.conftest import make_settings
+from tests.fakes import parse_jsonl
+
+GRADED = StageConfig(response_model=RelevanceJudgement[GradedRelevance])
+
+
+def rel_labels(capsys):
+    return [r["label"] for r in parse_jsonl(capsys.readouterr().out)
+            if r["stage"] == "rel_judge"]
+
+
+def test_session_defaults_to_the_binary_scale(patched_services, capsys):
+    settings = make_settings(plan=["query", "ranking", "click", "relevance"])
+    SessionRunner(settings=settings).run()
+
+    assert set(rel_labels(capsys)) == {"Relevant"}
+
+
+def test_session_honours_a_graded_scale(patched_services, capsys):
+    settings = make_settings(plan=["query", "ranking", "click", "relevance"],
+                             stages={"relevance": GRADED})
+    SessionRunner(settings=settings).run()
+
+    assert set(rel_labels(capsys)) == {"HighlyRelevant"}
+
+
+def test_agentic_honours_a_graded_scale(patched_services, capsys):
+    settings = make_settings(max_actions=10, stages={"relevance": GRADED})
+    AgenticRunner(settings=settings).run()
+
+    assert set(rel_labels(capsys)) == {"HighlyRelevant"}
+
+
+def test_repetition_honours_a_graded_scale(patched_services, capsys):
+    settings = make_settings(plan=["query", "ranking", "click", "relevance"],
+                             loop_num_per_topic=2, stages={"relevance": GRADED})
+    RepetitionRunner(settings=settings).run()
+
+    assert set(rel_labels(capsys)) == {"HighlyRelevant"}
+
+
+def test_the_model_asked_for_carries_the_chosen_scale(patched_services, capsys):
+    settings = make_settings(plan=["query", "ranking", "click", "relevance"],
+                             stages={"relevance": GRADED})
+    SessionRunner(settings=settings).run()
+    capsys.readouterr()
+
+    asked = [name for name, _ in patched_services.llm.calls
+             if name.startswith("RelevanceJudgement")]
+    assert asked == ["RelevanceJudgement[GradedRelevance]"] * 2  # one per topic


### PR DESCRIPTION
Closes #67.

Brings the label-scale abstraction to document-level judgement, in all three experiments.

```python
"relevance": StageConfig(
    response_model=RelevanceJudgement[GradedRelevance],
    instruction="""... define the four anchors here ...""",
),
```

## Changes

- `RelevanceJudgement` is generic in the label scale, like `SubtopicRelevanceJudgement`: `[Relevance]`, `[GradedRelevance]`, `[RubricRelevance]`. A bare class raises `specify a label scale, e.g. ...`.
- `StageConfig.response_model` is now honoured by the agentic and repetition relevance stages. Both hard-coded the schema at the `generate()` call, so no override reached them before — the per-subtopic one included.
- `RequiresLabelScale` moved above the models it serves, since `RelevanceJudgement` now inherits it.

## Nothing changes unless asked

The stage default is `RelevanceJudgement[Relevance]`, so an experiment that configures nothing produces the same binary judgement and the same records as before. Existing runner scripts need no edit.

As with the per-subtopic scales, the instruction defines what the labels mean and is not cross-checked against the scale. The built-in default instruction stays binary, matching the default scale.

## Tests

The default binary scale in the session runner; a graded scale honoured in each of the three runners; and the parametrised model actually asked for reaching the service. The fake now dispatches on a parametrised model's origin, since a parametrised generic is not its own origin class, and picks the most relevant label its scale offers so one scale is distinguishable from another. 78 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)