### PR TITLE
feat(llm): set schema_in_prompt per experiment; stop netting out its tokens

### DIFF
--- a/docs/advanced/json_handling.md
+++ b/docs/advanced/json_handling.md
@@ -46,7 +46,9 @@ Two settings change that, and they are independent.
   conversation, where models attend to them more than to the same text sent
   out of band. The schema then goes over the wire twice. The suffix rides on
   the outgoing copy only — session memory keeps the plain instruction, so
-  logged conversations stay identical across providers and settings.
+  logged conversations stay identical across providers and settings. Set it
+  per experiment on `ModelDescription`; the Gemini service has no equivalent
+  and ignores it.
 - `json_object_fallback` (default `False`) drops the `json_schema`
   `response_format` for deployments that mis-handle it, leaving no grammar.
   Such an entry must also set `schema_in_prompt`, or nothing tells the model
@@ -55,11 +57,12 @@ Two settings change that, and they are independent.
   (gpt-oss-120b), while the setting is per provider, so every model on that
   entry loses grammar enforcement whether or not it needs to.
 
-The two settings also decide how the schema's tokens are reported. Chosen as
-an experimental condition, they are a real cost and count toward
-`total_token`. Forced by `json_object_fallback`, they are excluded, so a
-provider that cannot do grammar is not made to look costlier than one sending
-the same schema out of band.
+`total_token` is what the provider reported, always — the schema's tokens are
+never netted out of it. Comparing providers where only some send the schema in
+the prompt therefore means subtracting at analysis time; the schema for a
+stage's response model can be re-serialised from `geniie_lab/response.py` and
+measured, bearing in mind that those models change over time, so an estimate
+made later is against today's schema rather than the one that ran.
 
 ## Reproducibility rationale
 

--- a/docs/experiments/common_settings.md
+++ b/docs/experiments/common_settings.md
@@ -101,6 +101,7 @@ my_settings = ExperimentSettings(
 - `top_p`: Nucleus (top-p) sampling probability, applied consistently across all LLM types (Default: 1.0)
 - `thinking_token_budget`: Reasoning models only — hard server-side cap on reasoning tokens per call (vLLM qwen3-class reasoning parsers; silently ignored elsewhere). `None` means uncapped (Default: `None`)
 - `reasoning_effort`: gpt-oss models only — trained-in reasoning-length dial, `low` | `medium` | `high`. `None` means the provider default (Default: `None`)
+- `schema_in_prompt`: Send the response schema in the prompt as well as out of band in `response_format`, so the field `title` and `description` text sits where the model attends to it. Costs the duplicated tokens, which are counted in `total_token`. `None` means the provider's own setting, and a provider with no grammar sends it regardless. See [Invalid JSON handling policy](../advanced/json_handling.md) (Default: `None`)
 
 See `scripts/run_session_experiment_reasoning.py` for a session template configured for reasoning models, including the recommended vLLM server flags.
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -24,6 +24,7 @@ The following parameters can be configured via `ExperimentSettings` in the runne
 |Model|All|`top_p`|1.0|Nucleus (top-p) sampling probability, applied consistently across all LLM types (Default: 1.0)|
 |Model|All|`thinking_token_budget`|1024|Reasoning models only: hard server-side cap on reasoning tokens per call, as a runaway guard. Enforced by vLLM's qwen3-class reasoning parsers; silently ignored by providers without the feature. Pair with a transition phrase in the server's `--reasoning-config reasoning_end_str` for a graceful cut. `None` means uncapped (Default: `None`)|
 |Model|All|`reasoning_effort`|low|gpt-oss models only: trained-in reasoning-length dial, `low`, `medium`, or `high`. The model plans its own reasoning depth; ignored by models without the knob. `None` means the provider default (Default: `None`)|
+|Model|All|`schema_in_prompt`|True|Send the response schema in the prompt as well as out of band in `response_format`, so the field descriptions sit where the model attends to them. Costs the duplicated tokens, which are included in `total_token`. `None` means the provider's own setting; providers with no grammar always send it (Default: `None`)|
 |Tool|All|`name`|opensearch|Name of search tool|
 |Tool|All|`ranking_model`|bm25|Name of ranking model used by the tool|
 |Tool|All|`encode_model`|opensearch-project/opensearch-neural-sparse-encoding-multilingual-v1|Name of the encoder model used by sparse/dense ranking models such as `splade` and `dpr`. Not needed for `bm25` (Default: `None`)|

--- a/geniie_lab/dataclasses/description.py
+++ b/geniie_lab/dataclasses/description.py
@@ -42,6 +42,9 @@ class ModelDescription:
     # "low" | "medium" | "high"; the model plans its own reasoning length).
     # None = provider default; ignored by models without the knob.
     reasoning_effort: Optional[str] = None
+    # Send the response schema in the prompt as well as in response_format.
+    # None = the provider's own setting; providers with no grammar always do.
+    schema_in_prompt: Optional[bool] = None
 
 @dataclass
 class ToolDescription:

--- a/geniie_lab/services/llm/openai_compatible.py
+++ b/geniie_lab/services/llm/openai_compatible.py
@@ -70,6 +70,7 @@ class OpenAICompatibleLLMService:
             model.name, model.token_length, model.temperature, model.top_p,
             memory, instruction, response_model,
             thinking_kwargs=self._thinking_kwargs(model),
+            schema_in_prompt=self._resolve_schema_in_prompt(model),
         )
 
     @staticmethod
@@ -80,6 +81,14 @@ class OpenAICompatibleLLMService:
         # models.
         return (getattr(message, "reasoning", None)
                 or getattr(message, "reasoning_content", None))
+
+    def _resolve_schema_in_prompt(self, model: ModelDescription) -> bool:
+        # Without a grammar there is nothing else to state the shape, so the
+        # fallback wins over any per-experiment setting.
+        if self._json_object_fallback:
+            return True
+        requested = getattr(model, "schema_in_prompt", None)
+        return self._schema_in_prompt if requested is None else requested
 
     @staticmethod
     def _thinking_kwargs(model: ModelDescription) -> dict:
@@ -105,6 +114,7 @@ class OpenAICompatibleLLMService:
         instruction: Instruction,
         response_model: Type[T],
         thinking_kwargs: dict = {},
+        schema_in_prompt: bool | None = None,
     ) -> Tuple[T, int, str | None]:
         tokenizer = self.get_tokenizer(model)
 
@@ -114,8 +124,9 @@ class OpenAICompatibleLLMService:
         # assistant turns must not be re-sent as user messages.
         messages: list[dict[str, str]] = memory.get_messages(tokenizer=tokenizer, max_tokens=token_length)
 
-        schema_tokens = 0
-        if self._schema_in_prompt:
+        if schema_in_prompt is None:
+            schema_in_prompt = self._schema_in_prompt
+        if schema_in_prompt:
             schema_suffix = (
                 "\n\nRespond with ONLY a JSON object that conforms to this JSON schema:\n"
                 + json.dumps(response_model.model_json_schema())
@@ -123,9 +134,6 @@ class OpenAICompatibleLLMService:
             messages = messages[:-1] + [
                 {**messages[-1], "content": messages[-1]["content"] + schema_suffix}
             ]
-            if self._json_object_fallback:
-                # Forced by the provider, so excluded to stay comparable.
-                schema_tokens = tokenizer(schema_suffix)
 
         if self._json_object_fallback:
             response_format = {"type": "json_object"}
@@ -157,7 +165,7 @@ class OpenAICompatibleLLMService:
             )
             usage = getattr(completion, "usage", None)
             call_tokens = getattr(usage, "total_tokens", 0) or 0
-            total_token += max(0, call_tokens - schema_tokens)
+            total_token += call_tokens
             message = completion.choices[0].message
             content = message.content or ""
             try:

--- a/tests/test_llm_services.py
+++ b/tests/test_llm_services.py
@@ -38,7 +38,8 @@ class StubClient:
 
 
 def _service_call(stub, thinking_token_budget=None, reasoning_effort=None,
-                  response_model=Query, **service_kwargs):
+                  response_model=Query, model_schema_in_prompt=None,
+                  **service_kwargs):
     service = OpenAICompatibleLLMService(client=stub, tiktoken_by_model=False, **service_kwargs)
     memory = ConversationHistory(system_role=None, system_prompt="be helpful")
     memory.add_user_message("earlier user turn")
@@ -47,7 +48,8 @@ def _service_call(stub, thinking_token_budget=None, reasoning_effort=None,
     model = ModelDescription(type="openai", name="some-model", token_length=100000,
                              temperature=0.0, top_p=1.0,
                              thinking_token_budget=thinking_token_budget,
-                             reasoning_effort=reasoning_effort)
+                             reasoning_effort=reasoning_effort,
+                             schema_in_prompt=model_schema_in_prompt)
     return service.generate(model, memory, instruction, response_model), memory
 
 
@@ -143,6 +145,31 @@ def test_json_object_fallback_drops_the_schema_response_format():
     assert stub.calls[0]["response_format"] == {"type": "json_object"}
 
 
+def test_experiment_can_request_the_schema_in_the_prompt():
+    stub = StubClient(VALID_QUERY_JSON)
+    _service_call(stub, model_schema_in_prompt=True)
+
+    assert "JSON schema" in stub.calls[0]["messages"][-1]["content"]
+    assert stub.calls[0]["response_format"]["type"] == "json_schema"
+
+
+def test_experiment_setting_overrides_the_provider_default():
+    stub = StubClient(VALID_QUERY_JSON)
+    _service_call(stub, schema_in_prompt=True, model_schema_in_prompt=False)
+
+    assert "JSON schema" not in stub.calls[0]["messages"][-1]["content"]
+
+
+def test_a_provider_without_grammar_keeps_the_schema_regardless():
+    # Nothing else states the shape there, so the experiment cannot switch it
+    # off; doing so would leave the model with no schema at all.
+    stub = StubClient(VALID_QUERY_JSON)
+    _service_call(stub, json_object_fallback=True, model_schema_in_prompt=False)
+
+    assert "JSON schema" in stub.calls[0]["messages"][-1]["content"]
+    assert stub.calls[0]["response_format"] == {"type": "json_object"}
+
+
 def test_bedrock_pairs_the_fallback_with_the_prompt_schema(monkeypatch):
     # The fallback has no grammar, so that registry entry must also ask for
     # the schema in the prompt or nothing tells the model what to produce.
@@ -154,22 +181,16 @@ def test_bedrock_pairs_the_fallback_with_the_prompt_schema(monkeypatch):
     assert service._schema_in_prompt is True
 
 
-def test_schema_tokens_count_when_the_schema_is_a_choice():
+def test_total_token_is_what_the_provider_reported():
+    # Never discounted, however the schema got into the prompt. Subtracting
+    # for comparability is the analysis script's decision, not the record's.
     stub = StubClient(VALID_QUERY_JSON)
-    (_, total_token, _), _ = _service_call(stub, schema_in_prompt=True)
+    (_, plain, _), _ = _service_call(stub)
+    (_, chosen, _), _ = _service_call(StubClient(VALID_QUERY_JSON), schema_in_prompt=True)
+    (_, forced, _), _ = _service_call(
+        StubClient(VALID_QUERY_JSON), schema_in_prompt=True, json_object_fallback=True)
 
-    assert total_token == 99  # the usage the provider reported, undiscounted
-
-
-def test_schema_tokens_are_excluded_when_the_provider_forces_them():
-    # A provider that cannot do grammar must send the schema in the prompt, so
-    # charging it for those tokens would make it look costlier than providers
-    # that send the same schema out of band.
-    stub = StubClient(VALID_QUERY_JSON)
-    (_, total_token, _), _ = _service_call(
-        stub, schema_in_prompt=True, json_object_fallback=True)
-
-    assert total_token < 99
+    assert plain == chosen == forced == 99
 
 
 def test_repaired_output_needs_no_second_call():


### PR DESCRIPTION
Closes #69. Follow-up to #63.

Two changes that only make sense together: the setting becomes an experiment's to make, and the accounting rule that could not have survived that goes away.

## Per experiment

```python
ModelDescription(type="openai", name="gpt-4.1-mini", token_length=1000000,
                 schema_in_prompt=True)
```

`None` keeps the provider registry's setting, so nothing changes for an experiment that says nothing. It sits on `ModelDescription` rather than `ExperimentSettings` because the service already receives that object in `generate()`, which is where `thinking_token_budget` and `reasoning_effort` are read; reaching `ExperimentSettings` would mean changing the protocol signature and all 13 stage call sites.

A provider with no grammar (`json_object_fallback`) sends the schema regardless — nothing else states the shape there, so an experiment must not be able to switch it off. A test covers that precedence.

The Gemini service has no equivalent and ignores the setting, like the other per-model controls it does not implement.

## Accounting

`total_token` is now what the provider reported, always.

The subtraction existed so a provider forced to send the suffix was not made to look costlier than one sending the same schema out of band. It could not stay coherent once an experiment can request the suffix on that same provider: in a schema-in-prompt condition, the forced provider would discount while the others counted. It also hid a real cost, recorded nothing about the adjustment, and was computed with our tokenizer rather than the provider's — on exactly the providers where `tiktoken_by_model=False`.

Subtracting for comparability moves to analysis, where a stage's schema can be re-serialised from `response.py` and measured. Recording it per call was considered and rejected: a fourth element on the `generate()` return and a field on six output dataclasses, for an overhead measured at 140-380 tokens per call.

## This changes outputs

`total_token` rises for providers that were having the suffix netted out — Bedrock is the only registry entry affected. Runner scripts are unaffected.

## Tests

The experiment setting requesting the schema; overriding the provider default in both directions; the no-grammar provider keeping it regardless; and `total_token` matching the reported usage in all three configurations. 80 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)