### PR TITLE
fix(subtopic): require the evidence key so the grammar cannot omit it

### DIFF
--- a/docs/advanced/subtopic_judgement.md
+++ b/docs/advanced/subtopic_judgement.md
@@ -80,6 +80,8 @@ The `rel_judge` record carries `labels`, one entry per presented subtopic, along
  "qrel_labels": {"1": 1, "2": 0}, "reason": "..."}
 ```
 
+Every entry carries an `evidence` key, because the schema requires it: the model cannot leave it out, only leave it empty, which is what the instruction asks for on `NotAddressed`.
+
 Two things to know when reading these records.
 
 `qrel_labels` has an entry for **every** presented subtopic, using 0 where the qrels record nothing. These collections record nonrelevance per document rather than per subtopic, so listing only the graded rows would hide every assessor "no" and make agreement look perfect by construction.

--- a/geniie_lab/response.py
+++ b/geniie_lab/response.py
@@ -156,8 +156,10 @@ class SubtopicRelevance(RequiresLabelScale[Label]):
         title="label",
         description="The relevance label for this subtopic, as defined in the instruction."
     )
+    # Required so the grammar cannot omit the key; "" is still a valid value,
+    # which is what the instruction asks for on NotAddressed.
     evidence: str = Field(
-        "",
+        ...,
         title="evidence",
         description=(
             "A verbatim quotation copied from the document that supports this "

--- a/tests/test_subtopic_judgement.py
+++ b/tests/test_subtopic_judgement.py
@@ -98,10 +98,22 @@ class TestSubtopicRelevanceJudgementSchema:
             labels=[{"subtopic": 1, "label": "Relevant", "evidence": "q"}], reason="r")
         assert judgement.labels[0].label is Relevance.RELEVANT
 
-    def test_evidence_defaults_empty(self):
+    def test_evidence_may_be_empty_but_not_omitted(self):
+        # The grammar must not let the model drop the key; the instruction is
+        # what says to leave it empty on NotAddressed.
         item = SubtopicRelevance[RubricRelevance](
-            subtopic=1, label=RubricRelevance.NOT_ADDRESSED)
+            subtopic=1, label=RubricRelevance.NOT_ADDRESSED, evidence="")
         assert item.evidence == ""
+        with pytest.raises(ValidationError):
+            SubtopicRelevance[RubricRelevance](
+                subtopic=1, label=RubricRelevance.NEED_SATISFIED)
+
+    def test_evidence_is_required_in_the_schema_sent_to_the_provider(self):
+        schema = SubtopicRelevanceJudgement[RubricRelevance].model_json_schema()
+        entry = schema["$defs"]["SubtopicRelevance_RubricRelevance_"]
+        assert set(entry["required"]) == {"subtopic", "label", "evidence"}
+        # Empty stays a legal value: required means present, not non-empty.
+        assert "minLength" not in entry["properties"]["evidence"]
 
     def test_reason_required(self):
         with pytest.raises(ValidationError):


### PR DESCRIPTION
Closes #73.

`evidence` had a default, so it was absent from the schema's `required` list and constrained decoding could drop the key. Omission is the cheap completion, so whether a quotation appeared depended on the model obeying the instruction, with the schema permitting the opposite. Pydantic then filled the default, leaving no trace in the record.

```
before: required = ["subtopic", "label"]
after:  required = ["subtopic", "label", "evidence"]
```

## The instruction's rule is unchanged

`required` means the key is present, not that it is non-empty. `""` stays a valid value, so `NotAddressed` still carries an empty quotation exactly as the instruction says. Only omitting the key becomes impossible.

The conditional one would rather express — non-empty only above `NotAddressed` — needs `if`/`then` subschemas, which strict structured-output modes do not accept. This is the closest enforceable approximation.

## On the report that prompted it

This was reported as a regression between two commits. It is not one: I built worktrees at both and found the generated schema and the full outgoing request (`response_format` and `messages`) byte-identical, for the same response model and `ModelDescription`. So this fixes a standing fragility, and the observed change of behaviour has another cause — most likely environmental.

## Cost

Every `NotAddressed` label now spends two extra tokens on `"evidence": ""`.

## Tests

Empty accepted, omission rejected, and the provider-facing schema listing `evidence` as required with no `minLength` so empty stays legal. 81 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)